### PR TITLE
daily dependabot runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: cron
-      cronjob: "10/15 * * * *"
+      cronjob: "10 13 * * *"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build(deps)"
@@ -16,7 +16,7 @@ updates:
     directory: "/"
     schedule:
       interval: cron
-      cronjob: "10/15 * * * *"
+      cronjob: "10 13 * * *"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "ci(deps)"
@@ -27,7 +27,7 @@ updates:
     directory: "/"
     schedule:
       interval: cron
-      cronjob: "10/15 * * * *"
+      cronjob: "10 13 * * *"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build(deps)"


### PR DESCRIPTION
> The property '#/updates/0/schedule/interval/cronjob' is invalid: Cronjob expression '10/15 * * * *' has a minimum interval of 0 hours which is less than the minimum allowed interval of 24 hours.