### PR TITLE
ci(frontend): e2e - don't use docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,33 @@ jobs:
       - name: Run backend tests
         run: pnpm --filter github-readme-stats run test
 
+  # Get playwright version from package.json
+  get-playwright-version:
+    name: Get Playwright version
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      v: ${{ steps.get-version.outputs.v }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
+
+      - name: Get Playwright version
+        id: get-version
+        run: |
+          VERSION=$(pnpm list @playwright/test --depth 0 --json | jq -r '.[0].devDependencies."@playwright/test".version')
+          echo "v=$VERSION" >> "$GITHUB_OUTPUT"
+
   frontend-test-e2e:
     name: Frontend E2E test
+
+    needs:
+      - get-playwright-version
 
     permissions:
       contents: read
@@ -74,7 +99,7 @@ jobs:
     #
     # @see https://playwright.dev/docs/docker
     container:
-      image: mcr.microsoft.com/playwright:v1.58.0-noble
+      image: mcr.microsoft.com/playwright:v${{ needs.get-playwright-version.outputs.v }}-noble
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,33 +52,8 @@ jobs:
       - name: Run backend tests
         run: pnpm --filter github-readme-stats run test
 
-  # Get playwright version from package.json
-  get-playwright-version:
-    name: Get Playwright version
-
-    runs-on: ubuntu-latest
-
-    outputs:
-      v: ${{ steps.get-version.outputs.v }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install Dependencies
-        uses: ./.github/actions/install-dependencies
-
-      - name: Get Playwright version
-        id: get-version
-        run: |
-          VERSION=$(pnpm list @playwright/test --depth 0 --json | jq -r '.[0].devDependencies."@playwright/test".version')
-          echo "v=$VERSION" >> "$GITHUB_OUTPUT"
-
   frontend-test-e2e:
     name: Frontend E2E test
-
-    needs:
-      - get-playwright-version
 
     permissions:
       contents: read
@@ -86,20 +61,6 @@ jobs:
     timeout-minutes: 60
 
     runs-on: ubuntu-latest
-
-    # Use official playwright docker image, which already includes browsers and related system dependencies.
-    # By doing this ci time we can skip the following step:
-    #
-    # ```yml
-    # - name: Install Playwright Browsers
-    #   run: pnpm exec playwright install --with-deps
-    # ```
-    #
-    # By doing so job execution time is reduced by ~20s
-    #
-    # @see https://playwright.dev/docs/docker
-    container:
-      image: mcr.microsoft.com/playwright:v${{ needs.get-playwright-version.outputs.v }}-noble
 
     steps:
       - name: Checkout code
@@ -112,6 +73,9 @@ jobs:
         run: |
           chmod +x ./vercel-preparation.sh
           ./vercel-preparation.sh
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
 
       - name: Run Playwright tests
         run: pnpm --filter frontend run test:e2e


### PR DESCRIPTION
- Followup of https://github.com/stats-organization/github-stats-extended/pull/91 

Dependabot does not update the version specified in the container image.
Reading the version directly from package.json prevents potential version mismatches.
