### PR TITLE
chore(vscode): update prettier extension id

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "yzhang.markdown-all-in-one",
-    "prettier.prettier-vscode",
+    "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "github.vscode-github-actions"
   ]


### PR DESCRIPTION
Update the Prettier extension ID.

Avoids prompting the user to install "Prettier (DO NOT USE)" extension.

<img width="473" height="130" alt="image" src="https://github.com/user-attachments/assets/ea422ba1-262c-402b-a8f0-cf4cbcbff011" />
