### PR TITLE
feat(frontend): add light/dark theming with theme picker

### DIFF
--- a/apps/frontend/e2e/app.spec.ts
+++ b/apps/frontend/e2e/app.spec.ts
@@ -12,8 +12,8 @@ test("load initial page correctly", async ({ page }) => {
   // Logo exists
   await expect(page.locator('img[alt="logo"]')).toBeVisible();
 
-  // Star on GitHub button
-  const starButton = page.getByRole("button", { name: /star on/i });
+  // Star on GitHub link
+  const starButton = page.getByRole("link", { name: /star on/i });
   await expect(starButton).toBeVisible();
 
   const githubLink = page.locator(
@@ -37,6 +37,45 @@ test("load initial page correctly", async ({ page }) => {
   const guestBtn = page.getByRole("button", { name: /continue as guest/i });
   await expect(guestBtn).toBeVisible();
   await expect(guestBtn).toBeEnabled();
+});
+
+test("theme picker switches and persists the theme", async ({ page }) => {
+  await page.goto("");
+
+  const html = page.locator("html");
+  const trigger = page.getByRole("button", { name: /choose theme/i });
+  const options = page.getByRole("menuitemradio");
+
+  // The menu is closed initially.
+  await expect(trigger).toBeVisible();
+  await expect(trigger).toHaveAttribute("aria-expanded", "false");
+  await expect(options).toHaveCount(0);
+
+  // Opening it reveals the options (portaled to body, above the stepper).
+  await trigger.click();
+  await expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+  // Read the themes off the options instead of hardcoding their names.
+  const firstTheme = await options.first().getAttribute("data-theme-value");
+  const lastTheme = await options.last().getAttribute("data-theme-value");
+
+  // Selecting an option applies the theme, persists it, and closes the menu.
+  await options.last().click();
+  await expect(html).toHaveAttribute("data-theme", lastTheme ?? "");
+  await expect(options).toHaveCount(0);
+  await expect(
+    page.evaluate(() => localStorage.getItem("theme")),
+  ).resolves.toBe(lastTheme);
+
+  // The choice survives a reload and is marked as selected on reopen.
+  await page.reload();
+  await expect(html).toHaveAttribute("data-theme", lastTheme ?? "");
+  await trigger.click();
+  await expect(options.last()).toHaveAttribute("aria-checked", "true");
+
+  // Switching to another option works too.
+  await options.first().click();
+  await expect(html).toHaveAttribute("data-theme", firstTheme ?? "");
 });
 
 test("navigates between steps", async ({ page }) => {

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -37,6 +37,22 @@
     <title>GitHub Stats Extended</title>
   </head>
   <body>
+    <script>
+      // Apply the persisted (or system) theme before first paint to avoid a flash.
+      // Also suppress color transitions until after the first paint so elements
+      // don't animate from their unstyled state on load.
+      (function () {
+        try {
+          var stored = localStorage.getItem("theme");
+          const matchesDarkTheme = window.matchMedia(
+            "(prefers-color-scheme: dark)",
+          ).matches;
+          var theme = stored || (matchesDarkTheme ? "dark" : "light");
+          document.documentElement.setAttribute("data-theme", theme);
+          document.documentElement.classList.add("no-transitions");
+        } catch (e) {}
+      })();
+    </script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -38,7 +38,10 @@
   </head>
   <body>
     <script>
-      // Apply the persisted (or system) theme before first paint to avoid a flash.
+      // Apply the persisted theme from localStorage before first paint. This is
+      // what makes a saved theme survive a reload when it differs from the OS
+      // preference (DaisyUI's `--prefersdark` only covers the OS default, and
+      // nothing in React sets `data-theme` on mount).
       // Also suppress color transitions until after the first paint so elements
       // don't animate from their unstyled state on load.
       (function () {
@@ -49,7 +52,6 @@
           ).matches;
           var theme = stored || (matchesDarkTheme ? "dark" : "light");
           document.documentElement.setAttribute("data-theme", theme);
-          document.documentElement.classList.add("no-transitions");
         } catch (e) {}
       })();
     </script>

--- a/apps/frontend/src/components/Card/Card.tsx
+++ b/apps/frontend/src/components/Card/Card.tsx
@@ -1,7 +1,8 @@
 import { clsx } from "clsx";
-import type { JSX } from "react";
+import type { CSSProperties, JSX } from "react";
 
 import { CardImage } from "./CardImage";
+import { LIGHT_CARD_BG } from "./themeBackdrop";
 
 interface CardProps {
   title: string;
@@ -28,17 +29,36 @@ export const Card = ({
   backgroundColor,
   titleColor,
 }: CardProps): JSX.Element => {
+  const customBackground = backgroundColor
+    ? selected
+      ? `color-mix(in oklab, var(--color-primary) ${backgroundColor === LIGHT_CARD_BG ? "10%" : "25%"}, ${backgroundColor})`
+      : backgroundColor
+    : undefined;
+
+  const cardStyle = customBackground
+    ? ({ "--card-bg": customBackground } as CSSProperties)
+    : undefined;
+
   return (
     <div
       className={clsx("p-6 rounded border-4", {
         "h-[370px] w-[510px]": fixedSize,
         "border-primary": selected,
         "border-base-300": !selected,
+        "bg-[var(--card-bg)]": !!customBackground,
         // Token backgrounds only apply when no custom background is given.
-        "bg-primary/10": selected && !backgroundColor,
-        "bg-base-100 hover:bg-base-200": !selected && !backgroundColor,
+        "bg-primary/10": selected && !customBackground,
+        "bg-base-100 hover:bg-base-200": !selected && !customBackground,
+        "hover:bg-base-300": !selected && !!customBackground,
       })}
-      style={backgroundColor ? { background: backgroundColor } : undefined}
+      style={cardStyle}
+      data-theme={
+        stage == 3
+          ? backgroundColor === LIGHT_CARD_BG || !backgroundColor
+            ? "light"
+            : "dark"
+          : undefined
+      }
     >
       <h2
         className="text-xl font-medium title-font text-base-content"

--- a/apps/frontend/src/components/Card/Card.tsx
+++ b/apps/frontend/src/components/Card/Card.tsx
@@ -11,6 +11,10 @@ interface CardProps {
   selected?: boolean;
   compact?: boolean;
   fixedSize?: boolean;
+  /** CSS background for the card surface (e.g. a theme's own background). */
+  backgroundColor?: string;
+  /** Title color, used when the card sits on a custom background. */
+  titleColor?: string;
 }
 
 export const Card = ({
@@ -21,16 +25,27 @@ export const Card = ({
   selected = false,
   compact = false,
   fixedSize = false,
+  backgroundColor,
+  titleColor,
 }: CardProps): JSX.Element => {
   return (
     <div
       className={clsx("p-6 rounded border-2", {
         "h-[370px] w-[510px]": fixedSize,
-        "border-blue-500 bg-blue-50": selected,
-        "border-gray-200 bg-white hover:bg-gray-50": !selected,
+        "border-primary": selected,
+        "border-base-300": !selected,
+        // Token backgrounds only apply when no custom background is given.
+        "bg-primary/10": selected && !backgroundColor,
+        "bg-base-100 hover:bg-base-200": !selected && !backgroundColor,
       })}
+      style={backgroundColor ? { background: backgroundColor } : undefined}
     >
-      <h2 className="text-xl font-medium title-font text-gray-900">{title}</h2>
+      <h2
+        className="text-xl font-medium title-font text-base-content"
+        style={titleColor ? { color: titleColor } : undefined}
+      >
+        {title}
+      </h2>
       <p className="text-base leading-relaxed mt-2 mb-4">{description}</p>
       <CardImage
         imageSrc={imageSrc}

--- a/apps/frontend/src/components/Card/Card.tsx
+++ b/apps/frontend/src/components/Card/Card.tsx
@@ -30,7 +30,7 @@ export const Card = ({
 }: CardProps): JSX.Element => {
   return (
     <div
-      className={clsx("p-6 rounded border-2", {
+      className={clsx("p-6 rounded border-4", {
         "h-[370px] w-[510px]": fixedSize,
         "border-primary": selected,
         "border-base-300": !selected,

--- a/apps/frontend/src/components/Card/themeBackdrop.ts
+++ b/apps/frontend/src/components/Card/themeBackdrop.ts
@@ -1,35 +1,90 @@
 import { themes } from "@stats-organization/github-readme-stats-core";
 
-// Cards sit on one of two backdrops, picked by how dark the card's theme is, so
-// previews read as a consistent two-tone set rather than a rainbow.
+// We use the same background colors here which GitHub uses.
 const LIGHT_CARD_BG = "#ffffff";
 const DARK_CARD_BG = "#0d1117";
 
-/**
- * Whether a theme's `bg_color` (a hex string or an `angle,c1,c2,…` gradient)
- * is dark, based on its perceived luminance. Fully transparent backgrounds
- * count as light.
- */
-function isDarkBg(bgColor: string): boolean {
-  const parts = bgColor.split(",");
-  // For gradients use the first color stop (index 0 is the angle).
-  const hex = (parts.length > 1 ? parts[1] : parts[0]) ?? "";
-  if (hex.length < 6 || (hex.length === 8 && hex.endsWith("00"))) {
+// Themes that look good in either mode (their text/icon colors read on both a
+// light and a dark backdrop), so their backdrop follows the app theme. Note we
+// only list themes that are genuinely mode-agnostic here: other transparent
+// themes (e.g. shadow_*) have dark text and must stay on a light backdrop.
+const ADAPTIVE_THEMES = ["transparent", "ambient_gradient"];
+
+/** Expand a shorthand `#abc` hex to `#aabbcc`. */
+function expandHex(hex: string): string {
+  if (hex.length === 3) {
+    return hex
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+  return hex;
+}
+
+/** Whether a hex color (3-, 6- or 8-digit) is dark by perceived luminance. */
+function isDarkHex(hex: string): boolean {
+  const normalized = expandHex(hex);
+  if (normalized.length < 6) {
     return false;
   }
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
   return luminance < 0.5;
 }
 
-/** The backdrop color a card rendered with the given theme should sit on. */
-export function getCardThemeBackdrop(themeName: string): string {
+/** Whether a theme's `bg_color` (hex or `angle,c1,c2,…` gradient) is dark. */
+function isDarkBg(bgColor: string): boolean {
+  const parts = bgColor.split(",");
+  // For gradients use the first color stop (index 0 is the angle).
+  return isDarkHex((parts.length > 1 ? parts[1] : parts[0]) ?? "");
+}
+
+/** A theme whose backdrop should follow the app mode rather than its own bg. */
+function isAdaptiveTheme(themeName: string): boolean {
+  return ADAPTIVE_THEMES.includes(themeName);
+}
+
+/**
+ * Whether the backdrop a card actually gets is dark, for the given app mode.
+ * Adaptive themes follow the app mode; the rest follow their own background.
+ */
+function isCardBackdropDark(themeName: string, appIsDark: boolean): boolean {
+  const theme = themes[themeName as keyof typeof themes];
+  if (isAdaptiveTheme(themeName)) {
+    return appIsDark;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!theme) {
+    return appIsDark;
+  }
+  return isDarkBg(theme.bg_color);
+}
+
+/**
+ * Sort rank for the theme grid: light themes first (0), adaptive themes in the
+ * middle (1), dark themes last (2). Adaptive cards sit between the groups so
+ * they blend with whichever side matches their backdrop in the current mode.
+ */
+export function getThemeSortRank(themeName: string): number {
+  if (isAdaptiveTheme(themeName)) {
+    return 1;
+  }
   const theme = themes[themeName as keyof typeof themes];
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!theme) {
-    return LIGHT_CARD_BG;
+    return 0;
   }
-  return isDarkBg(theme.bg_color) ? DARK_CARD_BG : LIGHT_CARD_BG;
+  return isDarkBg(theme.bg_color) ? 2 : 0;
+}
+
+/** The backdrop color a card rendered with the given theme should sit on. */
+export function getCardThemeBackdrop(
+  themeName: string,
+  appIsDark: boolean,
+): string {
+  return isCardBackdropDark(themeName, appIsDark)
+    ? DARK_CARD_BG
+    : LIGHT_CARD_BG;
 }

--- a/apps/frontend/src/components/Card/themeBackdrop.ts
+++ b/apps/frontend/src/components/Card/themeBackdrop.ts
@@ -1,0 +1,35 @@
+import { themes } from "@stats-organization/github-readme-stats-core";
+
+// Cards sit on one of two backdrops, picked by how dark the card's theme is, so
+// previews read as a consistent two-tone set rather than a rainbow.
+const LIGHT_CARD_BG = "#ffffff";
+const DARK_CARD_BG = "#0d1117";
+
+/**
+ * Whether a theme's `bg_color` (a hex string or an `angle,c1,c2,…` gradient)
+ * is dark, based on its perceived luminance. Fully transparent backgrounds
+ * count as light.
+ */
+function isDarkBg(bgColor: string): boolean {
+  const parts = bgColor.split(",");
+  // For gradients use the first color stop (index 0 is the angle).
+  const hex = (parts.length > 1 ? parts[1] : parts[0]) ?? "";
+  if (hex.length < 6 || (hex.length === 8 && hex.endsWith("00"))) {
+    return false;
+  }
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance < 0.5;
+}
+
+/** The backdrop color a card rendered with the given theme should sit on. */
+export function getCardThemeBackdrop(themeName: string): string {
+  const theme = themes[themeName as keyof typeof themes];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!theme) {
+    return LIGHT_CARD_BG;
+  }
+  return isDarkBg(theme.bg_color) ? DARK_CARD_BG : LIGHT_CARD_BG;
+}

--- a/apps/frontend/src/components/Card/themeBackdrop.ts
+++ b/apps/frontend/src/components/Card/themeBackdrop.ts
@@ -1,7 +1,7 @@
 import { themes } from "@stats-organization/github-readme-stats-core";
 
 // We use the same background colors here which GitHub uses.
-const LIGHT_CARD_BG = "#ffffff";
+export const LIGHT_CARD_BG = "#ffffff";
 const DARK_CARD_BG = "#0d1117";
 
 // Themes that look good in either mode (their text/icon colors read on both a

--- a/apps/frontend/src/components/Generic/Button.tsx
+++ b/apps/frontend/src/components/Generic/Button.tsx
@@ -9,19 +9,10 @@ interface ButtonProps extends Omit<HTMLProps<HTMLButtonElement>, "size"> {
   /** DaisyUI color variant. Omit for the default neutral button. */
   variant?: ButtonVariant | undefined;
   size?: ButtonSize;
-  /** Render the outlined style (`btn-outline`). */
-  outline?: boolean;
 }
 
 export function Button(props: ButtonProps): JSX.Element {
-  const {
-    className,
-    children,
-    variant,
-    size = "md",
-    outline = false,
-    ...rest
-  } = props;
+  const { className, children, variant, size = "md", ...rest } = props;
 
   return (
     <button
@@ -33,7 +24,6 @@ export function Button(props: ButtonProps): JSX.Element {
           "btn-primary": variant === "primary",
           "btn-neutral": variant === "neutral",
           "btn-error": variant === "error",
-          "btn-outline": outline,
           "btn-sm": size === "sm",
           "btn-lg": size === "lg",
         },

--- a/apps/frontend/src/components/Generic/Button.tsx
+++ b/apps/frontend/src/components/Generic/Button.tsx
@@ -1,7 +1,7 @@
 import { clsx } from "clsx";
 import type { HTMLProps, JSX, ReactNode } from "react";
 
-type ButtonVariant = "primary" | "neutral" | "error";
+type ButtonVariant = "primary" | "soft" | "error";
 type ButtonSize = "sm" | "md" | "lg";
 
 interface ButtonProps extends Omit<HTMLProps<HTMLButtonElement>, "size"> {
@@ -22,7 +22,7 @@ export function Button(props: ButtonProps): JSX.Element {
         "btn text-lg",
         {
           "btn-primary": variant === "primary",
-          "btn-neutral": variant === "neutral",
+          "btn-soft": variant === "soft",
           "btn-error": variant === "error",
           "btn-sm": size === "sm",
           "btn-lg": size === "lg",

--- a/apps/frontend/src/components/Generic/Button.tsx
+++ b/apps/frontend/src/components/Generic/Button.tsx
@@ -1,18 +1,42 @@
 import { clsx } from "clsx";
 import type { HTMLProps, JSX, ReactNode } from "react";
 
-interface ButtonProps extends HTMLProps<HTMLButtonElement> {
+type ButtonVariant = "primary" | "neutral" | "error";
+type ButtonSize = "sm" | "md" | "lg";
+
+interface ButtonProps extends Omit<HTMLProps<HTMLButtonElement>, "size"> {
   children: ReactNode;
+  /** DaisyUI color variant. Omit for the default neutral button. */
+  variant?: ButtonVariant | undefined;
+  size?: ButtonSize;
+  /** Render the outlined style (`btn-outline`). */
+  outline?: boolean;
 }
 
 export function Button(props: ButtonProps): JSX.Element {
-  const { className, children, ...rest } = props;
+  const {
+    className,
+    children,
+    variant,
+    size = "md",
+    outline = false,
+    ...rest
+  } = props;
+
   return (
     <button
       {...rest}
       type="button"
       className={clsx(
-        "border-0 py-2 px-6 inline-flex focus:outline-none rounded-[0.25rem] text-lg",
+        "btn text-lg",
+        {
+          "btn-primary": variant === "primary",
+          "btn-neutral": variant === "neutral",
+          "btn-error": variant === "error",
+          "btn-outline": outline,
+          "btn-sm": size === "sm",
+          "btn-lg": size === "lg",
+        },
         className,
       )}
     >

--- a/apps/frontend/src/components/Generic/Checkbox.tsx
+++ b/apps/frontend/src/components/Generic/Checkbox.tsx
@@ -19,7 +19,7 @@ export function Checkbox({
         type="checkbox"
         disabled={disabled}
         checked={checked}
-        className="checkbox bg-white text-[#18181b] mr-2"
+        className="checkbox checkbox-primary mr-2"
         onChange={() => {
           onCheckedChange(!checked);
         }}

--- a/apps/frontend/src/components/Generic/Select.tsx
+++ b/apps/frontend/src/components/Generic/Select.tsx
@@ -27,10 +27,7 @@ export function Select({
 }: SelectProps): JSX.Element {
   return (
     <select
-      className={clsx(
-        "text-gray-700 text-base bg-white select select-sm w-40 rounded-sm mt-4",
-        className,
-      )}
+      className={clsx("text-base select select-sm w-40 mt-4", className)}
       value={selectedOption.value}
       onChange={(e) => {
         onOptionChange(options[e.target.selectedIndex] as SelectOption);
@@ -43,7 +40,7 @@ export function Select({
           value={option.value}
           disabled={option.disabled}
           className={clsx({
-            "bg-blue-200": option.value === selectedOption.value,
+            "bg-primary/20": option.value === selectedOption.value,
           })}
         >
           {option.label}

--- a/apps/frontend/src/components/Generic/ThemePicker.tsx
+++ b/apps/frontend/src/components/Generic/ThemePicker.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { JSX } from "react";
+import { createPortal } from "react-dom";
+import {
+  FaCheck as CheckIcon,
+  FaMoon as MoonIcon,
+  FaSun as SunIcon,
+} from "react-icons/fa";
+
+import { useTheme } from "../../redux/selectors/themeSelectors";
+import { THEMES } from "../../redux/slices/theme";
+
+interface ThemeIconProps {
+  isDark: boolean;
+  className: string;
+}
+
+/** Sun for light themes, moon for dark ones. */
+function ThemeIcon({ isDark, className }: ThemeIconProps): JSX.Element {
+  return isDark ? (
+    <MoonIcon className={className} />
+  ) : (
+    <SunIcon className={className} />
+  );
+}
+
+export function ThemePicker(): JSX.Element {
+  const { theme, isDark, setTheme } = useTheme();
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, right: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLUListElement>(null);
+
+  const handleToggle = useCallback(() => {
+    if (!open && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + 8,
+        right: window.innerWidth - rect.right,
+      });
+    }
+    setOpen((value) => !value);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const close = () => {
+      setOpen(false);
+    };
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        !menuRef.current?.contains(target) &&
+        !buttonRef.current?.contains(target)
+      ) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", close);
+    // Close on scroll so the fixed menu can't detach from its button.
+    window.addEventListener("scroll", close, true);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", close);
+      window.removeEventListener("scroll", close, true);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className="btn btn-ghost btn-circle"
+        aria-label="Choose theme"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Choose theme"
+        onClick={handleToggle}
+      >
+        <ThemeIcon isDark={isDark} className="w-4 h-4" />
+      </button>
+
+      {open &&
+        createPortal(
+          <ul
+            ref={menuRef}
+            role="menu"
+            className="menu bg-base-200 text-base-content rounded-box fixed z-[9999] w-48 p-2 shadow-lg"
+            style={{ top: position.top, right: position.right }}
+          >
+            {THEMES.map((option) => (
+              <li key={option.name}>
+                <button
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={option.name === theme}
+                  data-theme-value={option.name}
+                  className="flex items-center justify-between"
+                  onClick={() => {
+                    setTheme(option.name);
+                    setOpen(false);
+                  }}
+                >
+                  <span className="flex items-center gap-2">
+                    <ThemeIcon isDark={option.isDark} className="w-4 h-4" />
+                    {option.label}
+                  </span>
+                  {option.name === theme && <CheckIcon className="w-3 h-3" />}
+                </button>
+              </li>
+            ))}
+          </ul>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/apps/frontend/src/components/Home/NumericSection.tsx
+++ b/apps/frontend/src/components/Home/NumericSection.tsx
@@ -61,7 +61,7 @@ export function NumericSection({
       <p>{description}</p>
       <input
         type="number"
-        className="input input-sm mt-2 w-1/4"
+        className="border border-base-content/20 rounded px-2 py-1 mt-2 w-1/4 bg-base-100"
         value={internalValue ?? ""}
         onChange={(e) => {
           setInternalValue(e.target.value);

--- a/apps/frontend/src/components/Home/NumericSection.tsx
+++ b/apps/frontend/src/components/Home/NumericSection.tsx
@@ -61,7 +61,7 @@ export function NumericSection({
       <p>{description}</p>
       <input
         type="number"
-        className="border border-gray-300 bg-white rounded px-2 py-1 mt-2 w-1/4"
+        className="input input-sm mt-2 w-1/4"
         value={internalValue ?? ""}
         onChange={(e) => {
           setInternalValue(e.target.value);

--- a/apps/frontend/src/components/Home/Progress.tsx
+++ b/apps/frontend/src/components/Home/Progress.tsx
@@ -24,7 +24,7 @@ function ProgressSection({
     <button
       className={clsx(
         "w-1/4 flex flex-col mx-2 p-2 cursor-pointer",
-        passed ? "border-primary" : "border-base-content/40",
+        passed ? "border-primary" : "border-base-content/60",
         isActive ? "border-t-[14px] -mt-[5px]" : "border-t-4",
       )}
       type="button"
@@ -33,13 +33,13 @@ function ProgressSection({
       <div
         className={clsx("text-lg font-bold", {
           "text-primary": passed,
-          "text-base-content/50": !passed,
+          "text-base-content/60": !passed,
           "-mt-[4px]": isActive,
         })}
       >
         {`Step ${num + 1}`}
       </div>
-      <div className={passed ? "text-base-content/70" : "text-base-content/50"}>
+      <div className={passed ? "text-base-content/80" : "text-base-content/60"}>
         {item}
       </div>
     </button>
@@ -61,7 +61,7 @@ export function ProgressBar({
   const rightDisabled = currItemIndex === items.length - 1;
 
   return (
-    <div className="w-full flex items-center sticky top-0 bg-base-200 z-50 pt-3 pb-1 px-1 md:px-20 shadow-md">
+    <div className="w-full flex items-center sticky top-0 bg-base-300 z-50 pt-3 pb-1 px-1 md:px-20 shadow-md">
       <button
         type="button"
         aria-label="Previous step"

--- a/apps/frontend/src/components/Home/Progress.tsx
+++ b/apps/frontend/src/components/Home/Progress.tsx
@@ -24,7 +24,7 @@ function ProgressSection({
     <button
       className={clsx(
         "w-1/4 flex flex-col mx-2 p-2 cursor-pointer",
-        passed ? "border-blue-500" : "border-gray-500",
+        passed ? "border-primary" : "border-base-content/40",
         isActive ? "border-t-[14px] -mt-[5px]" : "border-t-4",
       )}
       type="button"
@@ -32,14 +32,16 @@ function ProgressSection({
     >
       <div
         className={clsx("text-lg font-bold", {
-          "text-blue-500": passed,
-          "text-gray-500": !passed,
+          "text-primary": passed,
+          "text-base-content/50": !passed,
           "-mt-[4px]": isActive,
         })}
       >
         {`Step ${num + 1}`}
       </div>
-      <div className={passed ? "text-gray-700" : "text-gray-500"}>{item}</div>
+      <div className={passed ? "text-base-content/70" : "text-base-content/50"}>
+        {item}
+      </div>
     </button>
   );
 }
@@ -59,16 +61,23 @@ export function ProgressBar({
   const rightDisabled = currItemIndex === items.length - 1;
 
   return (
-    <div className="w-full flex items-center sticky top-0 bg-gray-200 z-50 pt-3 pb-1 px-1 md:px-20 shadow-md">
-      <LeftArrowIcon
-        className={clsx("w-8 h-8", {
-          "text-gray-400 cursor-not-allowed": leftDisabled,
-          "text-gray-700 cursor-pointer": !leftDisabled,
-        })}
+    <div className="w-full flex items-center sticky top-0 bg-base-200 z-50 pt-3 pb-1 px-1 md:px-20 shadow-md">
+      <button
+        type="button"
+        aria-label="Previous step"
+        disabled={leftDisabled}
+        className="btn btn-ghost btn-circle"
         onClick={() => {
           onItemClick(Math.max(currItemIndex - 1, 0));
         }}
-      />
+      >
+        <LeftArrowIcon
+          className={clsx("w-8 h-8", {
+            "text-base-content/30": leftDisabled,
+            "text-base-content/70": !leftDisabled,
+          })}
+        />
+      </button>
       <div className="px-2 flex-grow flex flex-row">
         {items.map((item, index) => {
           return (
@@ -85,15 +94,22 @@ export function ProgressBar({
           );
         })}
       </div>
-      <RightArrowIcon
-        className={clsx("w-8 h-8", {
-          "text-gray-400 cursor-not-allowed": rightDisabled,
-          "text-gray-700 cursor-pointer": !rightDisabled,
-        })}
+      <button
+        type="button"
+        aria-label="Next step"
+        disabled={rightDisabled}
+        className="btn btn-ghost btn-circle"
         onClick={() => {
           onItemClick(Math.min(currItemIndex + 1, items.length - 1));
         }}
-      />
+      >
+        <RightArrowIcon
+          className={clsx("w-8 h-8", {
+            "text-base-content/30": rightDisabled,
+            "text-base-content/70": !rightDisabled,
+          })}
+        />
+      </button>
     </div>
   );
 }

--- a/apps/frontend/src/components/Home/Section.tsx
+++ b/apps/frontend/src/components/Home/Section.tsx
@@ -10,14 +10,14 @@ export function Section({ title, children }: SectionProps): JSX.Element {
   return (
     <div className="flex relative pb-12">
       <div className="h-full w-10 absolute inset-0 flex items-center justify-center">
-        <div className="h-full w-1 bg-gray-200 pointer-events-none" />
+        <div className="h-full w-1 bg-base-300 pointer-events-none" />
       </div>
-      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-blue-500 inline-flex items-center justify-center text-white relative z-10">
+      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-primary inline-flex items-center justify-center text-primary-content relative z-10">
         <LightningIcon className="w-5 h-5" />
       </div>
 
       <div className="flex-grow pl-4">
-        <h2 className="font-medium title-font text-sm text-gray-900 mb-1 tracking-wider">
+        <h2 className="font-medium title-font text-sm text-base-content mb-1 tracking-wider">
           {title}
         </h2>
         {children}

--- a/apps/frontend/src/components/Home/TextSection.tsx
+++ b/apps/frontend/src/components/Home/TextSection.tsx
@@ -54,9 +54,10 @@ export function TextSection({
       <p>{description}</p>
       <input
         type="text"
-        className={clsx("input mt-2 w-3/4 min-w-48 max-w-xl", {
-          "cursor-not-allowed": disabled,
-        })}
+        className={clsx(
+          "border border-base-content/20 rounded px-2 py-1 mt-2 w-3/4 min-w-48 max-w-xl",
+          disabled ? "cursor-not-allowed bg-base-200" : "bg-base-100",
+        )}
         value={internalValue}
         onChange={(e) => {
           setInternalValue(e.target.value);

--- a/apps/frontend/src/components/Home/TextSection.tsx
+++ b/apps/frontend/src/components/Home/TextSection.tsx
@@ -54,10 +54,9 @@ export function TextSection({
       <p>{description}</p>
       <input
         type="text"
-        className={clsx(
-          "border border-gray-300 rounded px-2 py-1 mt-2 w-3/4 min-w-48 max-w-xl",
-          { "cursor-not-allowed bg-gray-100": disabled, "bg-white": !disabled },
-        )}
+        className={clsx("input mt-2 w-3/4 min-w-48 max-w-xl", {
+          "cursor-not-allowed": disabled,
+        })}
         value={internalValue}
         onChange={(e) => {
           setInternalValue(e.target.value);

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -11,15 +11,17 @@ Override background color in dark mode with GitHub's dark mode background color.
 */
 @plugin "daisyui/theme" {
   name: "light";
-  --color-primary: #2f80ed;
+  --color-error: var(--color-red-700);
 }
 @plugin "daisyui/theme" {
   name: "dark";
-  --color-primary: #2f80ed;
+  --color-error: var(--color-red-900);
   --color-base-100: #0d1117;
 }
 
 :root {
+  --color-primary: #2f80ed;
+
   /* Snappy duration for interactive elements (buttons, hovers). */
   --transition-fast: 100ms;
   /* Slower, deliberate fade for large surfaces during a theme switch. */
@@ -89,6 +91,13 @@ body,
 }
 .btn-soft:hover {
   background-color: color-mix(in oklab, var(--color-base-100), #888 60%);
+}
+.btn-error {
+  color: var(--color-neutral-content);
+}
+.btn-error:hover {
+  color: var(--color-neutral-content);
+  background-color: color-mix(in oklab, var(--color-error), #f00 40%);
 }
 
 input:focus,

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -1,14 +1,67 @@
-/* ./src/index.css */
 @import "tailwindcss";
-@plugin "daisyui";
+@plugin "daisyui" {
+  themes:
+    light --default,
+    dark --prefersdark;
+}
+
+:root {
+  /* Snappy duration for interactive elements (buttons, hovers). */
+  --transition-fast: 100ms;
+  /* Slower, deliberate fade for large surfaces during a theme switch. */
+  --transition-surface: 300ms;
+}
 
 body {
   margin: 0;
   font-family: "Segoe UI", Ubuntu, Sans-Serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: var(--color-base-100);
+  color: var(--color-base-content);
 }
 
-button {
-  cursor: pointer;
+/* Smoothly animate color changes when switching themes / on hover. */
+*,
+*::before,
+*::after {
+  transition-property: background-color, border-color, color, fill, stroke;
+  /* ease-out starts immediately; plain `ease` has a slow start that reads as a
+     delay on fast interactions like button hovers. */
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-duration: var(--transition-fast);
+}
+
+/*
+ * Large surface backgrounds fade more slowly so a theme switch reads as a
+ * deliberate fade rather than an instant flip. Durations reference the custom
+ * properties above so the reduced-motion override below zeroes them out
+ * regardless of selector specificity.
+ */
+body,
+.bg-base-100,
+.bg-base-200,
+.bg-base-300 {
+  transition-duration: var(--transition-surface);
+}
+
+/*
+ * DaisyUI's `.btn` ships its own 200ms transition which felt slow. Our global
+ * rule above is unlayered, so it would otherwise clobber the button's
+ * property list and easing. Restore both here (fill, text and border animate
+ * together for outline buttons; ease-out for an immediate response) and keep
+ * only the duration snappy.
+ */
+.btn {
+  transition-property: color, background-color, border-color, box-shadow;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+  transition-duration: var(--transition-fast);
+}
+
+/* Respect users who prefer reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --transition-fast: 0ms;
+    --transition-surface: 0ms;
+  }
 }

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -5,6 +5,20 @@
     dark --prefersdark;
 }
 
+/*
+Override primary color with default blue from github-stats-extended.
+Override background color in dark mode with GitHub's dark mode background color.
+*/
+@plugin "daisyui/theme" {
+  name: "light";
+  --color-primary: #2f80ed;
+}
+@plugin "daisyui/theme" {
+  name: "dark";
+  --color-primary: #2f80ed;
+  --color-base-100: #0d1117;
+}
+
 :root {
   /* Snappy duration for interactive elements (buttons, hovers). */
   --transition-fast: 100ms;
@@ -19,6 +33,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--color-base-100);
   color: var(--color-base-content);
+}
+
+button {
+  cursor: pointer;
 }
 
 /* Smoothly animate color changes when switching themes / on hover. */
@@ -60,14 +78,23 @@ body,
 }
 
 /* 
- * DaisyUI's default hover is very subtle; make it noticeable. Primary darkens,
- * while neutral (near-black in both themes) lightens so the change shows. 
+ * DaisyUI's default hover is very subtle; make it noticeable. Primary always darkens,
+ * while soft lightens in dark mode and darkens in light mode, so the change shows.
  */
 .btn-primary:hover {
-  background-color: color-mix(in oklab, var(--color-primary), #000 18%);
+  background-color: color-mix(in oklab, var(--color-primary), #000 30%);
 }
-.btn-neutral:hover {
-  background-color: color-mix(in oklab, var(--color-neutral), #fff 18%);
+.btn-soft {
+  background-color: color-mix(in oklab, var(--color-base-100), #888 35%);
+}
+.btn-soft:hover {
+  background-color: color-mix(in oklab, var(--color-base-100), #888 60%);
+}
+
+input:focus,
+select:focus {
+  outline: 0;
+  border: var(--color-primary) solid 1px;
 }
 
 /* Respect users who prefer reduced motion. */

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -26,8 +26,10 @@ body {
 *::before,
 *::after {
   transition-property: background-color, border-color, color, fill, stroke;
-  /* ease-out starts immediately; plain `ease` has a slow start that reads as a
-     delay on fast interactions like button hovers. */
+  /* 
+   * An ease-out curve: animations start at full speed so quick interactions
+   * like button hovers feel responsive instead of laggy. 
+   */
   transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
   transition-duration: var(--transition-fast);
 }
@@ -46,16 +48,26 @@ body,
 }
 
 /*
- * DaisyUI's `.btn` ships its own 200ms transition which felt slow. Our global
- * rule above is unlayered, so it would otherwise clobber the button's
- * property list and easing. Restore both here (fill, text and border animate
- * together for outline buttons; ease-out for an immediate response) and keep
- * only the duration snappy.
+ * DaisyUI's `.btn` ships its own 200ms transition which felt slow. The global
+ * rule above is unlayered, so it would otherwise clobber the button's property
+ * list and timing function. Restore both here (so fill, text and border animate
+ * together on outline buttons) and only speed up the duration.
  */
 .btn {
   transition-property: color, background-color, border-color, box-shadow;
   transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
   transition-duration: var(--transition-fast);
+}
+
+/* 
+ * DaisyUI's default hover is very subtle; make it noticeable. Primary darkens,
+ * while neutral (near-black in both themes) lightens so the change shows. 
+ */
+.btn-primary:hover {
+  background-color: color-mix(in oklab, var(--color-primary), #000 18%);
+}
+.btn-neutral:hover {
+  background-color: color-mix(in oklab, var(--color-neutral), #fff 18%);
 }
 
 /* Respect users who prefer reduced motion. */

--- a/apps/frontend/src/pages/App/AppTrends.tsx
+++ b/apps/frontend/src/pages/App/AppTrends.tsx
@@ -5,6 +5,7 @@ import { ToastContainer, toast } from "react-toastify";
 import { getUserMetadata } from "../../api/user";
 import { clearAxiosCache } from "../../axios-override";
 import type { StageIndex } from "../../models/Stage";
+import { useTheme } from "../../redux/selectors/themeSelectors";
 import {
   useIsAuthenticated,
   useUserKey,
@@ -56,6 +57,7 @@ export function AppTrends() {
   const userKey = useUserKey();
   const userToken = useUserToken();
   const isAuthenticated = useIsAuthenticated();
+  const { isDark } = useTheme();
 
   const [stage, setStage] = useState<StageIndex>(isAuthenticated ? 1 : 0);
 
@@ -116,9 +118,9 @@ export function AppTrends() {
   return (
     <div className="min-h-screen flex flex-col">
       <Header currStageIndex={stage} onStageIndexChange={setStage} />
-      <section className="bg-white text-gray-700 flex-grow">
+      <section className="bg-base-100 text-base-content flex-grow">
         <HomeScreen stage={stage} setStage={setStage} />
-        <ToastContainer />
+        <ToastContainer theme={isDark ? "dark" : "light"} />
       </section>
     </div>
   );

--- a/apps/frontend/src/pages/App/Header.tsx
+++ b/apps/frontend/src/pages/App/Header.tsx
@@ -20,7 +20,13 @@ export function Header({
 }: HeaderProps): JSX.Element {
   return (
     <>
-      <div className="text-neutral-content bg-neutral shadow-md z-50">
+      <div
+        className="text-neutral-content shadow-md z-50"
+        style={{
+          backgroundColor:
+            "color-mix(in oklab, var(--color-primary), #000 50%)",
+        }}
+      >
         <div className="px-5 py-2 flex flex-wrap">
           {/* Logo */}
           <a

--- a/apps/frontend/src/pages/App/Header.tsx
+++ b/apps/frontend/src/pages/App/Header.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import { FaGithub as GithubIcon } from "react-icons/fa";
 
 import appIcon from "../../assets/appLogo64.png";
+import { ThemePicker } from "../../components/Generic/ThemePicker";
 import { ProgressBar } from "../../components/Home/Progress";
 import { STAGE_LABELS } from "../../models/Stage";
 import type { StageIndex } from "../../models/Stage";
@@ -19,31 +20,28 @@ export function Header({
 }: HeaderProps): JSX.Element {
   return (
     <>
-      <div className="text-gray-100 bg-gray-800 shadow-md z-50">
+      <div className="text-neutral-content bg-neutral shadow-md z-50">
         <div className="px-5 py-2 flex flex-wrap">
           {/* Logo */}
           <a
             href="/"
-            className="flex items-center title-font font-medium text-gray-50 mb-0 md:mr-8"
+            className="flex items-center title-font font-medium text-neutral-content mb-0 md:mr-8"
           >
             <img src={appIcon} alt="logo" className="w-6 h-6" />
             <span className="ml-2 text-xl">GitHub Stats Extended</span>
           </a>
-          {/* Star on GitHub */}
-          <div className="flex ml-auto items-center text-base justify-center">
+          {/* Star on GitHub + theme toggle */}
+          <div className="flex ml-auto items-center gap-2 text-base justify-center">
             <a
               href="https://github.com/stats-organization/github-stats-extended"
               target="_blank"
               rel="noopener noreferrer"
+              className="rounded-[0.25rem] shadow bg-neutral-content hover:opacity-90 text-neutral px-3 py-1 flex items-center"
             >
-              <button
-                type="button"
-                className="rounded-[0.25rem] shadow bg-gray-200 hover:bg-gray-300 text-black px-3 py-1 flex items-center"
-              >
-                Star on
-                <GithubIcon className="ml-1.5 w-5 h-5" />
-              </button>
+              Star on
+              <GithubIcon className="ml-1.5 w-5 h-5" />
             </a>
+            <ThemePicker />
           </div>
         </div>
       </div>

--- a/apps/frontend/src/pages/Home/Home.tsx
+++ b/apps/frontend/src/pages/Home/Home.tsx
@@ -230,11 +230,14 @@ export function HomeScreen({ stage, setStage }: HomeScreenProps): JSX.Element {
   }
 
   return (
-    <div ref={contentSectionRef} className="h-full px-2 lg:px-8 text-gray-600">
+    <div
+      ref={contentSectionRef}
+      className="h-full px-2 lg:px-8 text-base-content/70"
+    >
       <div className="flex flex-col">
         <div className="m-4 rounded-sm">
           <div className="lg:p-4">
-            <h1 className="text-2xl text-gray-600 font-semibold">
+            <h1 className="text-2xl text-base-content/70 font-semibold">
               {STAGE_LABELS[stage].title}
             </h1>
             <div>
@@ -245,7 +248,7 @@ export function HomeScreen({ stage, setStage }: HomeScreenProps): JSX.Element {
                     <a
                       href={`https://github.com/${userId}`}
                       target="_blank"
-                      className="text-blue-500 hover:underline font-semibold"
+                      className="text-primary hover:underline font-semibold"
                     >
                       {userId}
                     </a>
@@ -382,6 +385,7 @@ export function HomeScreen({ stage, setStage }: HomeScreenProps): JSX.Element {
                     return "";
                 }
               })()}
+              theme={theme}
               themeSuffix={themeSuffix}
               guestHint={
                 isAuthenticated

--- a/apps/frontend/src/pages/Home/Home.tsx
+++ b/apps/frontend/src/pages/Home/Home.tsx
@@ -19,6 +19,7 @@ import {
 import { CardType } from "../../models/CardType";
 import { STAGE_LABELS } from "../../models/Stage";
 import type { StageIndex } from "../../models/Stage";
+import { useTheme } from "../../redux/selectors/themeSelectors";
 import {
   useIsAuthenticated,
   usePrivateAccess,
@@ -83,7 +84,9 @@ export function HomeScreen({ stage, setStage }: HomeScreenProps): JSX.Element {
   const [enableAnimations, setEnableAnimations] = useState(true);
   const [usePercent, setUsePercent] = useState(false);
 
-  const [theme, setTheme] = useState("default");
+  const { isDark } = useTheme();
+  const themeParam = isDark ? "&theme=github_dark" : "";
+  const [theme, setTheme] = useState(isDark ? "dark" : "default");
 
   const handleCardTypeChange = (cardType: CardType) => {
     if (cardType === CardType.TOP_LANGS) {
@@ -331,7 +334,7 @@ export function HomeScreen({ stage, setStage }: HomeScreenProps): JSX.Element {
               setWakatimeUser={setWakatimeUser}
               usePercent={usePercent}
               setUsePercent={setUsePercent}
-              fullSuffix={fullSuffix}
+              fullSuffix={fullSuffix + themeParam}
               setStage={setStage}
             />
           )}

--- a/apps/frontend/src/pages/Home/stages/Customize.tsx
+++ b/apps/frontend/src/pages/Home/stages/Customize.tsx
@@ -109,7 +109,7 @@ export function CustomizeStage({
 
   return (
     <div className="w-full flex flex-wrap">
-      <div className="h-auto lg:w-2/5 md:w-1/2 p-10 rounded-sm bg-gray-200">
+      <div className="h-auto lg:w-2/5 md:w-1/2 p-10 rounded-sm bg-base-200">
         {(cardType === CardType.STATS || cardType === CardType.TOP_LANGS) && (
           <TextSection
             title="Username"
@@ -126,7 +126,7 @@ export function CustomizeStage({
                         e.preventDefault();
                         setStage(0);
                       }}
-                      className="underline text-blue-900"
+                      className="underline text-primary"
                     >
                       log in
                     </a>{" "}
@@ -170,7 +170,7 @@ export function CustomizeStage({
                         e.preventDefault();
                         setStage(0);
                       }}
-                      className="underline text-blue-900"
+                      className="underline text-primary"
                     >
                       log in
                     </a>{" "}
@@ -214,7 +214,7 @@ export function CustomizeStage({
                         e.preventDefault();
                         setStage(0);
                       }}
-                      className="underline text-blue-900"
+                      className="underline text-primary"
                     >
                       log in
                     </a>{" "}
@@ -251,7 +251,7 @@ export function CustomizeStage({
                 <a
                   href="https://wakatime.com/"
                   target="_blank"
-                  className="underline text-blue-900"
+                  className="underline text-primary"
                 >
                   WakaTime
                 </a>{" "}
@@ -411,7 +411,7 @@ export function CustomizeStage({
           <a
             href="https://github.com/stats-organization/github-stats-extended/blob/master/docs/advanced_documentation.md"
             target="_blank"
-            className="underline text-blue-900"
+            className="underline text-primary"
           >
             customization documentation
           </a>{" "}

--- a/apps/frontend/src/pages/Home/stages/Display.tsx
+++ b/apps/frontend/src/pages/Home/stages/Display.tsx
@@ -1,15 +1,16 @@
-import { clsx } from "clsx";
 import type { JSX } from "react";
 import { toast } from "react-toastify";
 import { saveSvgAsPng } from "save-svg-as-png";
 
 import { CardImage } from "../../../components/Card/CardImage";
+import { getCardThemeBackdrop } from "../../../components/Card/themeBackdrop";
 import { Button } from "../../../components/Generic/Button";
 import { HOST } from "../../../constants";
 
 interface DisplayStageProps {
   filename: string;
   link: string;
+  theme: string;
   themeSuffix: string;
   guestHint: string | null;
 }
@@ -17,6 +18,7 @@ interface DisplayStageProps {
 export function DisplayStage({
   filename,
   link,
+  theme,
   themeSuffix,
   guestHint,
 }: DisplayStageProps): JSX.Element {
@@ -61,7 +63,7 @@ export function DisplayStage({
   return (
     <div className="w-full flex flex-wrap">
       <div className="h-auto lg:w-2/5 md:w-1/2">
-        <div className="p-10 rounded-sm bg-gray-200">
+        <div className="p-10 rounded-sm bg-base-200">
           <div className="flex flex-col items-center">
             {[
               {
@@ -82,10 +84,9 @@ export function DisplayStage({
             ].map((item) => (
               <Button
                 key={item.title}
-                className={clsx("m-4 w-60 flex justify-center", {
-                  "bg-blue-500 hover:bg-blue-600 text-white": item.highlight,
-                  "bg-white hover:bg-gray-100 text-black": !item.highlight,
-                })}
+                variant={item.highlight ? "primary" : undefined}
+                outline={!item.highlight}
+                className="m-4 w-60 flex justify-center"
                 onClick={item.onClick}
               >
                 {item.title}
@@ -96,10 +97,14 @@ export function DisplayStage({
         </div>
       </div>
       <div className="w-full lg:w-3/5 md:w-1/2 object-center pt-5 md:pt-0 pl-0 md:pl-5 lg:pl-0">
-        <div className="w-full lg:w-3/5 mx-auto flex flex-col justify-center sticky top-32">
+        <div
+          className="w-full lg:w-3/5 mx-auto flex flex-col justify-center sticky top-32 rounded p-4"
+          style={{ background: getCardThemeBackdrop(theme) }}
+        >
           <CardImage
             imageSrc={`${themeSuffix}&disable_animations=true`}
             stage={4}
+            className="flex justify-center"
           />
         </div>
       </div>

--- a/apps/frontend/src/pages/Home/stages/Display.tsx
+++ b/apps/frontend/src/pages/Home/stages/Display.tsx
@@ -6,6 +6,7 @@ import { CardImage } from "../../../components/Card/CardImage";
 import { getCardThemeBackdrop } from "../../../components/Card/themeBackdrop";
 import { Button } from "../../../components/Generic/Button";
 import { HOST } from "../../../constants";
+import { useTheme } from "../../../redux/selectors/themeSelectors";
 
 interface DisplayStageProps {
   filename: string;
@@ -22,6 +23,8 @@ export function DisplayStage({
   themeSuffix,
   guestHint,
 }: DisplayStageProps): JSX.Element {
+  const { isDark } = useTheme();
+
   const downloadPNG = () => {
     saveSvgAsPng(
       document.getElementById("svgWrapper")?.shadowRoot?.firstElementChild
@@ -84,8 +87,7 @@ export function DisplayStage({
             ].map((item) => (
               <Button
                 key={item.title}
-                variant={item.highlight ? "primary" : undefined}
-                outline={!item.highlight}
+                variant={item.highlight ? "primary" : "neutral"}
                 className="m-4 w-60 flex justify-center"
                 onClick={item.onClick}
               >
@@ -99,7 +101,7 @@ export function DisplayStage({
       <div className="w-full lg:w-3/5 md:w-1/2 object-center pt-5 md:pt-0 pl-0 md:pl-5 lg:pl-0">
         <div
           className="w-full lg:w-3/5 mx-auto flex flex-col justify-center sticky top-32 rounded p-4"
-          style={{ background: getCardThemeBackdrop(theme) }}
+          style={{ background: getCardThemeBackdrop(theme, isDark) }}
         >
           <CardImage
             imageSrc={`${themeSuffix}&disable_animations=true`}

--- a/apps/frontend/src/pages/Home/stages/Display.tsx
+++ b/apps/frontend/src/pages/Home/stages/Display.tsx
@@ -87,7 +87,7 @@ export function DisplayStage({
             ].map((item) => (
               <Button
                 key={item.title}
-                variant={item.highlight ? "primary" : "neutral"}
+                variant={item.highlight ? "primary" : "soft"}
                 className="m-4 w-60 flex justify-center"
                 onClick={item.onClick}
               >

--- a/apps/frontend/src/pages/Home/stages/Login/LoginAccountDeleteModal.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginAccountDeleteModal.tsx
@@ -60,12 +60,7 @@ export function LoginAccountDeleteModal(
             <Button variant="primary" onClick={onClose}>
               Cancel
             </Button>
-            <Button
-              variant="error"
-              outline
-              className="ml-auto"
-              onClick={onConfirm}
-            >
+            <Button variant="error" className="ml-auto" onClick={onConfirm}>
               Delete Account
             </Button>
           </div>

--- a/apps/frontend/src/pages/Home/stages/Login/LoginAccountDeleteModal.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginAccountDeleteModal.tsx
@@ -45,7 +45,7 @@ export function LoginAccountDeleteModal(
     <div className="fixed left-0 top-0 w-full h-full">
       <div className="w-full h-full flex justify-center items-center">
         <div
-          className="w-96 p-4 bg-white rounded-sm border-2 border-gray-200 text-gray-700"
+          className="w-96 p-4 bg-base-100 rounded-sm border-2 border-base-300 text-base-content"
           ref={wrapperRef}
         >
           <p className="mb-1 text-2xl">Delete Account</p>
@@ -57,14 +57,13 @@ export function LoginAccountDeleteModal(
           </p>
           <br />
           <div className="flex flex-wrap">
-            <Button
-              className="bg-blue-500 hover:bg-blue-600 text-white rounded-[0.25rem]"
-              onClick={onClose}
-            >
+            <Button variant="primary" onClick={onClose}>
               Cancel
             </Button>
             <Button
-              className="bg-gray-200 hover:bg-gray-300 ml-auto rounded-[0.25rem] text-red-600 border-2"
+              variant="error"
+              outline
+              className="ml-auto"
               onClick={onConfirm}
             >
               Delete Account

--- a/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
@@ -57,7 +57,7 @@ export function LoginAccountManagement(): JSX.Element {
               href={`https://${HOST}/api/downgrade?user_key=${userKey as string}`}
             >
               <Button
-                outline
+                variant="neutral"
                 className="h-12 flex justify-center items-center w-[320px]"
               >
                 <GithubIcon className="w-6 h-6" />
@@ -95,7 +95,7 @@ export function LoginAccountManagement(): JSX.Element {
       {/* Delete Account Button */}
       <div className="mt-6 flex items-center gap-4">
         <Button
-          outline
+          variant="neutral"
           className="h-12 flex justify-center items-center w-[320px]"
           onClick={openDeleteModal}
         >
@@ -110,7 +110,7 @@ export function LoginAccountManagement(): JSX.Element {
       {/* Logout Button */}
       <div className="mt-6 flex items-center gap-4">
         <Button
-          outline
+          variant="neutral"
           className="h-12 flex justify-center items-center w-[320px]"
           onClick={handleLogout}
         >

--- a/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
@@ -56,14 +56,17 @@ export function LoginAccountManagement(): JSX.Element {
             <a
               href={`https://${HOST}/api/downgrade?user_key=${userKey as string}`}
             >
-              <Button className="h-12 flex justify-center items-center w-[320px] text-black border border-black bg-white hover:bg-gray-100">
+              <Button
+                outline
+                className="h-12 flex justify-center items-center w-[320px]"
+              >
                 <GithubIcon className="w-6 h-6" />
                 <span className="ml-2 xl:text-lg">
                   Downgrade to Public Access
                 </span>
               </Button>
             </a>
-            <p className="text-sm text-gray-600 flex-1">
+            <p className="text-sm text-base-content/70 flex-1">
               Switch to public access if you prefer not to share private
               contributions.
             </p>
@@ -71,14 +74,17 @@ export function LoginAccountManagement(): JSX.Element {
         ) : (
           <div className="flex items-center gap-4">
             <a href={GITHUB_PRIVATE_AUTH_URL}>
-              <Button className="h-12 flex justify-center items-center w-[320px] text-white bg-blue-500 hover:bg-blue-600">
+              <Button
+                variant="primary"
+                className="h-12 flex justify-center items-center w-[320px]"
+              >
                 <GithubIcon className="w-6 h-6" />
                 <span className="ml-2 xl:text-lg">
                   Upgrade to Private Access
                 </span>
               </Button>
             </a>
-            <p className="text-sm text-gray-600 flex-1">
+            <p className="text-sm text-base-content/70 flex-1">
               Upgrade to include contributions in private repositories for more
               complete and accurate stats.
             </p>
@@ -89,12 +95,13 @@ export function LoginAccountManagement(): JSX.Element {
       {/* Delete Account Button */}
       <div className="mt-6 flex items-center gap-4">
         <Button
-          className="h-12 flex justify-center items-center w-[320px] text-black border border-black bg-white hover:bg-gray-100"
+          outline
+          className="h-12 flex justify-center items-center w-[320px]"
           onClick={openDeleteModal}
         >
-          <span className="xl:text-lg text-red-600">Delete Account</span>
+          <span className="xl:text-lg text-error">Delete Account</span>
         </Button>
-        <p className="text-sm text-gray-600 flex-1">
+        <p className="text-sm text-base-content/70 flex-1">
           This will delete your GitHub-Stats-Extended account and then redirect
           you to a GitHub screen where you can revoke your access token.
         </p>
@@ -103,12 +110,13 @@ export function LoginAccountManagement(): JSX.Element {
       {/* Logout Button */}
       <div className="mt-6 flex items-center gap-4">
         <Button
-          className="h-12 flex justify-center items-center w-[320px] text-black border border-black bg-white hover:bg-gray-100"
+          outline
+          className="h-12 flex justify-center items-center w-[320px]"
           onClick={handleLogout}
         >
           <span className="xl:text-lg">Log Out</span>
         </Button>
-        <p className="text-sm text-gray-600 flex-1">
+        <p className="text-sm text-base-content/70 flex-1">
           Log out from GitHub-Stats-Extended.
         </p>
       </div>

--- a/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
@@ -57,7 +57,7 @@ export function LoginAccountManagement(): JSX.Element {
               href={`https://${HOST}/api/downgrade?user_key=${userKey as string}`}
             >
               <Button
-                variant="neutral"
+                variant="soft"
                 className="h-12 flex justify-center items-center w-[320px]"
               >
                 <GithubIcon className="w-6 h-6" />
@@ -95,7 +95,7 @@ export function LoginAccountManagement(): JSX.Element {
       {/* Delete Account Button */}
       <div className="mt-6 flex items-center gap-4">
         <Button
-          variant="neutral"
+          variant="soft"
           className="h-12 flex justify-center items-center w-[320px]"
           onClick={openDeleteModal}
         >
@@ -110,7 +110,7 @@ export function LoginAccountManagement(): JSX.Element {
       {/* Logout Button */}
       <div className="mt-6 flex items-center gap-4">
         <Button
-          variant="neutral"
+          variant="soft"
           className="h-12 flex justify-center items-center w-[320px]"
           onClick={handleLogout}
         >

--- a/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginAccountManagement.tsx
@@ -99,7 +99,9 @@ export function LoginAccountManagement(): JSX.Element {
           className="h-12 flex justify-center items-center w-[320px]"
           onClick={openDeleteModal}
         >
-          <span className="xl:text-lg text-error">Delete Account</span>
+          <span className="xl:text-lg text-error text-shadow-none">
+            Delete Account
+          </span>
         </Button>
         <p className="text-sm text-base-content/70 flex-1">
           This will delete your GitHub-Stats-Extended account and then redirect

--- a/apps/frontend/src/pages/Home/stages/Login/LoginBox.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginBox.tsx
@@ -16,7 +16,7 @@ export function LoginBox(props: LoginBoxProps): JSX.Element {
     <div className="h-full flex flex-wrap">
       <div className={clsx("md:flex", { "opacity-25": isOpaque })}>
         <div className="lg:block lg:w-3/5 lg:p-8">
-          <div className="bg-base-200 rounded-sm w-full h-full m-auto p-8 shadow lg:h-auto">
+          <div className="bg-base-300 rounded-sm w-full h-full m-auto p-8 shadow lg:h-auto">
             {children}
           </div>
         </div>

--- a/apps/frontend/src/pages/Home/stages/Login/LoginBox.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginBox.tsx
@@ -16,7 +16,7 @@ export function LoginBox(props: LoginBoxProps): JSX.Element {
     <div className="h-full flex flex-wrap">
       <div className={clsx("md:flex", { "opacity-25": isOpaque })}>
         <div className="lg:block lg:w-3/5 lg:p-8">
-          <div className="bg-gray-200 rounded-sm w-full h-full m-auto p-8 shadow lg:h-auto">
+          <div className="bg-base-200 rounded-sm w-full h-full m-auto p-8 shadow lg:h-auto">
             {children}
           </div>
         </div>

--- a/apps/frontend/src/pages/Home/stages/Login/LoginBoxDemoCards.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginBoxDemoCards.tsx
@@ -7,6 +7,7 @@ import {
   DEMO_USER,
   DEMO_WAKATIME_USER,
 } from "../../../../constants";
+import { useTheme } from "../../../../redux/selectors/themeSelectors";
 
 const cards: Array<{ demoImageSrc: string }> = [
   {
@@ -39,6 +40,10 @@ function getCardXPosition(cardIndex: number): number {
 }
 
 export function LoginBoxDemoCards(): JSX.Element {
+  const { isDark } = useTheme();
+  // Show dark-themed demo cards in dark mode so they fit the surroundings.
+  const themeParam = isDark ? "&theme=github_dark" : "";
+
   return (
     <div className="w-full h-full lg:w-2/5 flex lg:flex-col lg:p-8 relative overflow-hidden">
       <div className="relative w-full h-full">
@@ -52,7 +57,11 @@ export function LoginBoxDemoCards(): JSX.Element {
               marginBottom: "1%",
             }}
           >
-            <CardImage imageSrc={card.demoImageSrc} compact={false} stage={0} />
+            <CardImage
+              imageSrc={`${card.demoImageSrc}${themeParam}`}
+              compact={false}
+              stage={0}
+            />
           </div>
         ))}
       </div>

--- a/apps/frontend/src/pages/Home/stages/Login/LoginOptions.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginOptions.tsx
@@ -20,24 +20,30 @@ export function LoginOptions(props: LoginOptionsProps): JSX.Element {
     <LoginBox>
       <div className="flex items-center gap-4 mb-4">
         <a href={GITHUB_PUBLIC_AUTH_URL}>
-          <Button className="h-12 flex justify-center items-center w-[260px] text-white bg-blue-500 hover:bg-blue-600">
+          <Button
+            variant="primary"
+            className="h-12 flex justify-center items-center w-[260px]"
+          >
             <GithubIcon className="w-6 h-6" />
-            <span className="ml-2 xl:text-lg">GitHub Public Access</span>
+            GitHub Public Access
           </Button>
         </a>
-        <p className="text-sm text-gray-600 flex-1">
+        <p className="text-sm text-base-content/70 flex-1">
           Generate stats based on your contributions in public repositories.
         </p>
       </div>
 
       <div className="flex items-center gap-4 mb-4">
         <a href={GITHUB_PRIVATE_AUTH_URL}>
-          <Button className="h-12 flex justify-center items-center w-[260px] text-black border border-black bg-white hover:bg-gray-100">
+          <Button
+            outline
+            className="h-12 flex justify-center items-center w-[260px]"
+          >
             <GithubIcon className="w-6 h-6" />
-            <span className="ml-2 xl:text-lg">GitHub Private Access</span>
+            GitHub Private Access
           </Button>
         </a>
-        <p className="text-sm text-gray-600 flex-1">
+        <p className="text-sm text-base-content/70 flex-1">
           Include contributions from private repositories for more complete and
           accurate stats.
         </p>
@@ -45,12 +51,13 @@ export function LoginOptions(props: LoginOptionsProps): JSX.Element {
 
       <div className="flex items-center gap-4">
         <Button
-          className="h-12 flex justify-center items-center w-[260px] text-black border border-black bg-white hover:bg-gray-100"
+          outline
+          className="h-12 flex justify-center items-center w-[260px]"
           onClick={onContinueAsGuest}
         >
-          <span className="ml-2 xl:text-lg">Continue as Guest</span>
+          Continue as Guest
         </Button>
-        <p className="text-sm text-gray-600 flex-1">
+        <p className="text-sm text-base-content/70 flex-1">
           Explore options using sample data. Insert your own username in the
           last step.
         </p>

--- a/apps/frontend/src/pages/Home/stages/Login/LoginOptions.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginOptions.tsx
@@ -36,7 +36,7 @@ export function LoginOptions(props: LoginOptionsProps): JSX.Element {
       <div className="flex items-center gap-4 mb-4">
         <a href={GITHUB_PRIVATE_AUTH_URL}>
           <Button
-            outline
+            variant="neutral"
             className="h-12 flex justify-center items-center w-[260px]"
           >
             <GithubIcon className="w-6 h-6" />
@@ -51,7 +51,7 @@ export function LoginOptions(props: LoginOptionsProps): JSX.Element {
 
       <div className="flex items-center gap-4">
         <Button
-          outline
+          variant="neutral"
           className="h-12 flex justify-center items-center w-[260px]"
           onClick={onContinueAsGuest}
         >

--- a/apps/frontend/src/pages/Home/stages/Login/LoginOptions.tsx
+++ b/apps/frontend/src/pages/Home/stages/Login/LoginOptions.tsx
@@ -28,7 +28,7 @@ export function LoginOptions(props: LoginOptionsProps): JSX.Element {
             GitHub Public Access
           </Button>
         </a>
-        <p className="text-sm text-base-content/70 flex-1">
+        <p className="text-sm text-base-content/80 flex-1">
           Generate stats based on your contributions in public repositories.
         </p>
       </div>
@@ -36,14 +36,14 @@ export function LoginOptions(props: LoginOptionsProps): JSX.Element {
       <div className="flex items-center gap-4 mb-4">
         <a href={GITHUB_PRIVATE_AUTH_URL}>
           <Button
-            variant="neutral"
+            variant="soft"
             className="h-12 flex justify-center items-center w-[260px]"
           >
             <GithubIcon className="w-6 h-6" />
             GitHub Private Access
           </Button>
         </a>
-        <p className="text-sm text-base-content/70 flex-1">
+        <p className="text-sm text-base-content/80 flex-1">
           Include contributions from private repositories for more complete and
           accurate stats.
         </p>
@@ -51,13 +51,13 @@ export function LoginOptions(props: LoginOptionsProps): JSX.Element {
 
       <div className="flex items-center gap-4">
         <Button
-          variant="neutral"
+          variant="soft"
           className="h-12 flex justify-center items-center w-[260px]"
           onClick={onContinueAsGuest}
         >
           Continue as Guest
         </Button>
-        <p className="text-sm text-base-content/70 flex-1">
+        <p className="text-sm text-base-content/80 flex-1">
           Explore options using sample data. Insert your own username in the
           last step.
         </p>

--- a/apps/frontend/src/pages/Home/stages/SelectCard.tsx
+++ b/apps/frontend/src/pages/Home/stages/SelectCard.tsx
@@ -9,6 +9,7 @@ import {
   DEMO_WAKATIME_USER,
 } from "../../../constants";
 import { CardType } from "../../../models/CardType";
+import { useTheme } from "../../../redux/selectors/themeSelectors";
 import { useUserId } from "../../../redux/selectors/userSelectors";
 
 interface SelectCardStageProps {
@@ -21,6 +22,9 @@ export function SelectCardStage({
   onCardTypeChange,
 }: SelectCardStageProps): JSX.Element {
   const userId = useUserId(DEMO_USER);
+  const { isDark } = useTheme();
+  // Show dark-themed demo cards in dark mode so they fit the surroundings.
+  const themeParam = isDark ? "&theme=github_dark" : "";
 
   const options = useMemo<
     Array<{
@@ -34,37 +38,37 @@ export function SelectCardStage({
       {
         title: "GitHub Stats Card",
         description: "your overall GitHub statistics",
-        demoImageSrc: `?username=${userId}&include_all_commits=true`,
+        demoImageSrc: `?username=${userId}&include_all_commits=true${themeParam}`,
         cardType: CardType.STATS,
       },
       {
         title: "Top Languages Card",
         description: "your most frequently used languages",
-        demoImageSrc: `/top-langs?username=${userId}&langs_count=4`,
+        demoImageSrc: `/top-langs?username=${userId}&langs_count=4${themeParam}`,
         cardType: CardType.TOP_LANGS,
       },
       {
         title: "GitHub Extra Pin",
         description:
           "pin more than 6 repositories in your profile using a GitHub profile readme",
-        demoImageSrc: `/pin?repo=${DEMO_REPO}`,
+        demoImageSrc: `/pin?repo=${DEMO_REPO}${themeParam}`,
         cardType: CardType.PIN,
       },
       {
         title: "GitHub Gist Pin",
         description:
           "pin gists in your GitHub profile using a GitHub profile readme",
-        demoImageSrc: `/gist?id=${DEMO_GIST}`,
+        demoImageSrc: `/gist?id=${DEMO_GIST}${themeParam}`,
         cardType: CardType.GIST,
       },
       {
         title: "WakaTime Stats Card",
         description: "your coding activity from WakaTime",
-        demoImageSrc: `/wakatime?username=${DEMO_WAKATIME_USER}&langs_count=6&card_width=450`,
+        demoImageSrc: `/wakatime?username=${DEMO_WAKATIME_USER}&langs_count=6&card_width=450${themeParam}`,
         cardType: CardType.WAKATIME,
       },
     ],
-    [userId],
+    [userId, themeParam],
   );
 
   return (

--- a/apps/frontend/src/pages/Home/stages/Theme.tsx
+++ b/apps/frontend/src/pages/Home/stages/Theme.tsx
@@ -2,7 +2,11 @@ import { themes } from "@stats-organization/github-readme-stats-core";
 import type { JSX } from "react";
 
 import { Card } from "../../../components/Card/Card";
-import { getCardThemeBackdrop } from "../../../components/Card/themeBackdrop";
+import {
+  getCardThemeBackdrop,
+  getThemeSortRank,
+} from "../../../components/Card/themeBackdrop";
+import { useTheme } from "../../../redux/selectors/themeSelectors";
 
 const excludedThemes = [
   "merko",
@@ -13,9 +17,10 @@ const excludedThemes = [
   "holi",
 ];
 
-const themeList = Object.keys(themes).filter(
-  (myTheme) => !excludedThemes.includes(myTheme),
-);
+// Light themes first, adaptive themes in the middle, dark themes last.
+const themeList = Object.keys(themes)
+  .filter((myTheme) => !excludedThemes.includes(myTheme))
+  .sort((a, b) => getThemeSortRank(a) - getThemeSortRank(b));
 
 interface ThemeStageProps {
   fullSuffix: string;
@@ -28,6 +33,8 @@ export function ThemeStage({
   fullSuffix,
   onThemeChange,
 }: ThemeStageProps): JSX.Element {
+  const { isDark } = useTheme();
+
   return (
     <>
       <div className="flex flex-wrap">
@@ -48,7 +55,7 @@ export function ThemeStage({
                 imageSrc={`${fullSuffix}&theme=${myTheme}`}
                 selected={theme === myTheme}
                 stage={3}
-                backgroundColor={getCardThemeBackdrop(myTheme)}
+                backgroundColor={getCardThemeBackdrop(myTheme, isDark)}
                 titleColor={`#${themeColors.title_color}`}
               />
             </button>

--- a/apps/frontend/src/pages/Home/stages/Theme.tsx
+++ b/apps/frontend/src/pages/Home/stages/Theme.tsx
@@ -2,6 +2,7 @@ import { themes } from "@stats-organization/github-readme-stats-core";
 import type { JSX } from "react";
 
 import { Card } from "../../../components/Card/Card";
+import { getCardThemeBackdrop } from "../../../components/Card/themeBackdrop";
 
 const excludedThemes = [
   "merko",
@@ -30,35 +31,40 @@ export function ThemeStage({
   return (
     <>
       <div className="flex flex-wrap">
-        {themeList.map((myTheme) => (
-          <button
-            className="p-2 lg:p-4"
-            key={myTheme}
-            type="button"
-            onClick={() => {
-              onThemeChange(myTheme);
-            }}
-          >
-            <Card
-              title={myTheme}
-              description=""
-              imageSrc={`${fullSuffix}&theme=${myTheme}`}
-              selected={theme === myTheme}
-              stage={3}
-            />
-          </button>
-        ))}
+        {themeList.map((myTheme) => {
+          const themeColors = themes[myTheme as keyof typeof themes];
+          return (
+            <button
+              className="p-2 lg:p-4"
+              key={myTheme}
+              type="button"
+              onClick={() => {
+                onThemeChange(myTheme);
+              }}
+            >
+              <Card
+                title={myTheme}
+                description=""
+                imageSrc={`${fullSuffix}&theme=${myTheme}`}
+                selected={theme === myTheme}
+                stage={3}
+                backgroundColor={getCardThemeBackdrop(myTheme)}
+                titleColor={`#${themeColors.title_color}`}
+              />
+            </button>
+          );
+        })}
       </div>
       <div className="pl-10 pr-10">
-        For more theme options check the{" "}
+        {"For more theme options check the "}
         <a
           href="https://github.com/stats-organization/github-stats-extended/blob/master/docs/advanced_documentation.md#themes"
           target="_blank"
-          className="underline text-blue-900"
+          className="underline text-primary"
         >
           customization documentation
-        </a>{" "}
-        after you copied your card URL in step 5.
+        </a>
+        {" after you copied your card URL in step 5."}
       </div>
     </>
   );

--- a/apps/frontend/src/pages/Home/stages/Theme.tsx
+++ b/apps/frontend/src/pages/Home/stages/Theme.tsx
@@ -56,7 +56,11 @@ export function ThemeStage({
                 selected={theme === myTheme}
                 stage={3}
                 backgroundColor={getCardThemeBackdrop(myTheme, isDark)}
-                titleColor={`#${themeColors.title_color}`}
+                titleColor={`#${
+                  myTheme === "ambient_gradient" && !isDark
+                    ? (themes["ambient_gradient"].bg_color.split(",")[1] ?? "")
+                    : themeColors.title_color
+                }`}
               />
             </button>
           );

--- a/apps/frontend/src/redux/selectors/themeSelectors.ts
+++ b/apps/frontend/src/redux/selectors/themeSelectors.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { isDarkTheme, setTheme as setThemeAction } from "../slices/theme";
+import type { StoreState } from "../store";
+
+/**
+ * Reads the active DaisyUI theme from the Redux store and exposes a setter
+ * that persists the choice and updates the `data-theme` attribute.
+ */
+export function useTheme(): {
+  theme: string;
+  isDark: boolean;
+  setTheme: (theme: string) => void;
+} {
+  const dispatch = useDispatch();
+  const theme = useSelector((state: StoreState) => state.theme.theme);
+
+  const setTheme = useCallback(
+    (next: string) => {
+      dispatch(setThemeAction(next));
+    },
+    [dispatch],
+  );
+
+  return { theme, isDark: isDarkTheme(theme), setTheme };
+}

--- a/apps/frontend/src/redux/slices/theme.ts
+++ b/apps/frontend/src/redux/slices/theme.ts
@@ -1,0 +1,69 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+interface ThemeOption {
+  /** DaisyUI theme name, used as the `data-theme` value. */
+  name: string;
+  label: string;
+  /** Whether the theme has a dark background (drives toast styling, etc.). */
+  isDark: boolean;
+}
+
+/**
+ * Themes exposed in the theme picker.
+ * Keep in sync with the `themes:` list in `index.css`.
+ */
+export const THEMES: ReadonlyArray<ThemeOption> = [
+  { name: "light", label: "Light", isDark: false },
+  { name: "dark", label: "Dark", isDark: true },
+];
+
+const DEFAULT_LIGHT_THEME = "light";
+const DEFAULT_DARK_THEME = "dark";
+
+function isValidTheme(name: string | null): name is string {
+  return !!name && THEMES.some((theme) => theme.name === name);
+}
+
+export function isDarkTheme(name: string): boolean {
+  return THEMES.find((theme) => theme.name === name)?.isDark ?? false;
+}
+
+/**
+ * @public
+ * Exported so the inferred store type can name it (see the note in `user.ts`).
+ */
+export interface ThemeState {
+  theme: string;
+}
+
+function getInitialTheme(): string {
+  const stored = localStorage.getItem("theme");
+  if (isValidTheme(stored)) {
+    return stored;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? DEFAULT_DARK_THEME
+    : DEFAULT_LIGHT_THEME;
+}
+
+const initialState: ThemeState = {
+  theme: getInitialTheme(),
+};
+
+const themeSlice = createSlice({
+  name: "theme",
+  initialState,
+  reducers: {
+    setTheme: (state, action: PayloadAction<string>) => {
+      const theme = action.payload;
+      localStorage.setItem("theme", theme);
+      document.documentElement.setAttribute("data-theme", theme);
+      state.theme = theme;
+    },
+  },
+});
+
+export const { setTheme } = themeSlice.actions;
+
+export default themeSlice.reducer;

--- a/apps/frontend/src/redux/store.ts
+++ b/apps/frontend/src/redux/store.ts
@@ -3,11 +3,13 @@ import { configureStore } from "@reduxjs/toolkit";
 import { USE_LOGGER } from "../constants";
 
 import { loggerMiddleware } from "./logger";
+import theme from "./slices/theme";
 import user from "./slices/user";
 
 const store = configureStore({
   reducer: {
     user,
+    theme,
   },
   middleware: (getDefaultMiddleware) => {
     const middleware = getDefaultMiddleware();


### PR DESCRIPTION
Adds light/dark theming to the frontend using the existing DaisyUI + Tailwind setup.

- Theme picker dropdown in the header; selection is stored in Redux and persisted to `localStorage`. 
  The toggle and each option show a sun/moon icon (shared `ThemeIcon` component) so light/dark are easy to tell apart.
- Migrated hardcoded colors to DaisyUI tokens so the whole UI (and toasts) follow the theme.
- `Button` now uses `variant` / `size` / `outline` props instead of raw `btn-*` classes.
- Theme preview cards: (Select Theme grid and the final Display card) sit on a two-tone backdrop (light or dark), chosen by the card theme so previews stay consistent regardless of the app theme.
- Smooth theme-switch transitions: surfaces fade gently while interactive elements stay snappy; respects `prefers-reduced-motion`.
- Added an e2e test for the picker.


<details><summary>Step 1</summary>
<p>


<img width="1710" height="811" alt="Screenshot 2026-06-24 at 06 54 40" src="https://github.com/user-attachments/assets/38d629b5-eaa3-4fb1-b976-c56e7a840ced" />

<img width="1706" height="808" alt="Screenshot 2026-06-24 at 06 54 32" src="https://github.com/user-attachments/assets/3811a574-016c-4a93-82a9-a340519f5257" />


</p>
</details> 

<details><summary>Step 4</summary>
<p>


<img width="1709" height="899" alt="Screenshot 2026-06-24 at 06 56 22" src="https://github.com/user-attachments/assets/4053b938-1faa-427b-b621-e79ce7b2c7b1" />

<img width="1705" height="894" alt="Screenshot 2026-06-24 at 06 55 41" src="https://github.com/user-attachments/assets/8aace78a-f1ca-4d29-b57e-938f7b473e67" />

</p>
</details> 