### PR TITLE
fix color of theme switcher

### DIFF
--- a/apps/frontend/src/components/Generic/ThemePicker.tsx
+++ b/apps/frontend/src/components/Generic/ThemePicker.tsx
@@ -84,7 +84,7 @@ export function ThemePicker(): JSX.Element {
       <button
         ref={buttonRef}
         type="button"
-        className="btn btn-ghost btn-circle"
+        className="btn btn-ghost btn-circle  not-[&:hover]:text-current"
         aria-label="Choose theme"
         aria-haspopup="menu"
         aria-expanded={open}


### PR DESCRIPTION
The latest daisyui upgrade changed the theme switcher's color in light mode. This PR reverts that change.