### PR TITLE
fix(core): validate username / gist id against the safe-character pattern

### DIFF
--- a/packages/core/src/api/gist.js
+++ b/packages/core/src/api/gist.js
@@ -43,6 +43,24 @@ export default async (
     };
   }
 
+  const safePattern = /^[-\w/.,]+$/;
+  if (id && !safePattern.test(id)) {
+    return {
+      status: "error - permanent",
+      content: renderError({
+        message: "Something went wrong",
+        secondaryMessage: "Gist ID contains unsafe characters",
+        renderOptions: {
+          title_color,
+          text_color,
+          bg_color,
+          border_color,
+          theme,
+        },
+      }),
+    };
+  }
+
   try {
     const gistData = await fetchGist(id, pat);
 

--- a/packages/core/src/api/top-langs.js
+++ b/packages/core/src/api/top-langs.js
@@ -55,10 +55,27 @@ export default async (
     };
   }
 
+  const safePattern = /^[-\w/.,]+$/;
+  if (username && !safePattern.test(username)) {
+    return {
+      status: "error - permanent",
+      content: renderError({
+        message: "Something went wrong",
+        secondaryMessage: "Username contains unsafe characters",
+        renderOptions: {
+          title_color,
+          text_color,
+          bg_color,
+          border_color,
+          theme,
+        },
+      }),
+    };
+  }
+
   if (
     layout !== undefined &&
-    (typeof layout !== "string" ||
-      !["compact", "normal", "donut", "donut-vertical", "pie"].includes(layout))
+    !["compact", "normal", "donut", "donut-vertical", "pie"].includes(layout)
   ) {
     return {
       status: "error - permanent",
@@ -78,8 +95,7 @@ export default async (
 
   if (
     stats_format !== undefined &&
-    (typeof stats_format !== "string" ||
-      !["bytes", "percentages"].includes(stats_format))
+    !["bytes", "percentages"].includes(stats_format)
   ) {
     return {
       status: "error - permanent",

--- a/packages/core/src/api/wakatime.js
+++ b/packages/core/src/api/wakatime.js
@@ -49,6 +49,24 @@ export default async ({
     };
   }
 
+  const safePattern = /^[-\w/.,]+$/;
+  if (username && !safePattern.test(username)) {
+    return {
+      status: "error - permanent",
+      content: renderError({
+        message: "Something went wrong",
+        secondaryMessage: "Username contains unsafe characters",
+        renderOptions: {
+          title_color,
+          text_color,
+          bg_color,
+          border_color,
+          theme,
+        },
+      }),
+    };
+  }
+
   try {
     const stats = await fetchWakatimeStats({ username, api_domain });
 

--- a/packages/core/tests/apiInputValidation.test.js
+++ b/packages/core/tests/apiInputValidation.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import gistApi from "../src/api/gist.js";
+import statsApi from "../src/api/index.js";
+import pinApi from "../src/api/pin.js";
+import topLangsApi from "../src/api/top-langs.js";
+import wakatimeApi from "../src/api/wakatime.js";
+
+// Values containing characters outside the safe set /^[-\w/.,]+$/. These must be
+// rejected before any network request is made.
+const unsafeValues = ["user name", "user@evil.com", "a<b", "a?b", "a:b", "a&b"];
+
+describe("API input validation", () => {
+  describe.each([
+    ["top-langs", "username", topLangsApi],
+    ["wakatime", "username", wakatimeApi],
+    ["gist", "id", gistApi],
+    ["stats", "username", statsApi],
+    ["stats", "repo", statsApi],
+    ["stats", "owner", statsApi],
+    ["pin", "username", pinApi],
+    ["pin", "repo", pinApi],
+  ])("%s: %s", (_endpoint, param, api) => {
+    it.each(unsafeValues)(`rejects unsafe ${param} %j`, async (value) => {
+      const result = await api({ [param]: value });
+      expect(result.status).toBe("error - permanent");
+      expect(result.content).toContain("unsafe characters");
+    });
+  });
+});


### PR DESCRIPTION
- Related to #342 

`stats` and `pin` already reject `username`/`repo`/`owner` that don't match `safePattern` (`/^[-\w/.,]+$/`), but `top-langs`, `wakatime`, and `gist` didn't.

This applies the same guard:

- `top-langs` + `wakatime`: reject a `username` containing unsafe characters.
  Matters most for `wakatime`, where `username` is interpolated into the outbound  request URL path.
- `gist`: same guard on its `id` param.

All three return the existing `error - permanent` card before any fetch.

## Additional change

Simplified the `layout` / `stats_format` checks in `top-langs`: 
dropped the redundant `typeof x !== "string" ||` (a non-string already fails `.includes(...)`), 
keeping the `x !== undefined` guard so the params stay optional.