### PR TITLE
longer prerender caching

### DIFF
--- a/apps/backend/_dot_vercel_copy/output/functions/api.prerender-config.json
+++ b/apps/backend/_dot_vercel_copy/output/functions/api.prerender-config.json
@@ -1,5 +1,5 @@
 {
-  "expiration": 39600,
+  "expiration": 147600,
   "bypassToken": "r3fr3shT0k3n-r3fr3shT0k3n-r3fr3shT0k3n",
   "passQuery": true
 }

--- a/apps/backend/_dot_vercel_copy/output/functions/api/gist.prerender-config.json
+++ b/apps/backend/_dot_vercel_copy/output/functions/api/gist.prerender-config.json
@@ -1,5 +1,5 @@
 {
-  "expiration": 39600,
+  "expiration": 147600,
   "bypassToken": "r3fr3shT0k3n-r3fr3shT0k3n-r3fr3shT0k3n",
   "passQuery": true
 }

--- a/apps/backend/_dot_vercel_copy/output/functions/api/pin.prerender-config.json
+++ b/apps/backend/_dot_vercel_copy/output/functions/api/pin.prerender-config.json
@@ -1,5 +1,5 @@
 {
-  "expiration": 39600,
+  "expiration": 147600,
   "bypassToken": "r3fr3shT0k3n-r3fr3shT0k3n-r3fr3shT0k3n",
   "passQuery": true
 }

--- a/apps/backend/_dot_vercel_copy/output/functions/api/top-langs.prerender-config.json
+++ b/apps/backend/_dot_vercel_copy/output/functions/api/top-langs.prerender-config.json
@@ -1,5 +1,5 @@
 {
-  "expiration": 39600,
+  "expiration": 147600,
   "bypassToken": "r3fr3shT0k3n-r3fr3shT0k3n-r3fr3shT0k3n",
   "passQuery": true
 }

--- a/apps/backend/_dot_vercel_copy/output/functions/api/wakatime.prerender-config.json
+++ b/apps/backend/_dot_vercel_copy/output/functions/api/wakatime.prerender-config.json
@@ -1,5 +1,5 @@
 {
-  "expiration": 39600,
+  "expiration": 147600,
   "bypassToken": "r3fr3shT0k3n-r3fr3shT0k3n-r3fr3shT0k3n",
   "passQuery": true
 }


### PR DESCRIPTION
Load on Vercel is higher than expected. It seems the problem is that Vercel's CDN evicts our responses before they go stale, because there are relatively few requests per card. So the repeat-recent functionality currently causes load without achieving much.

This PR increases ISR expiration time to see how this affects load in practice. Setting this time via env var might be a task for later.