### PR TITLE
Split GraphQL queries / Omit contributed when expensive

### DIFF
--- a/packages/core/src/cards/stats.js
+++ b/packages/core/src/cards/stats.js
@@ -482,12 +482,14 @@ const renderStatsCard = (
     };
   }
 
-  STATS.contribs = {
-    icon: icons.contribs,
-    label: i18n.t("statcard.contribs"),
-    value: contributedTo,
-    id: "contribs",
-  };
+  if (contributedTo !== null) {
+    STATS.contribs = {
+      icon: icons.contribs,
+      label: i18n.t("statcard.contribs"),
+      value: contributedTo,
+      id: "contribs",
+    };
+  }
 
   // @ts-ignore
   const isLongLocale = locale ? LONG_LOCALES.includes(locale) : false;

--- a/packages/core/src/fetchers/stats.js
+++ b/packages/core/src/fetchers/stats.js
@@ -35,20 +35,11 @@ const GRAPHQL_REPOS_QUERY = `
   }
 `;
 
-const GRAPHQL_STATS_QUERY = `
-  query userInfo($login: String!, $after: String, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!, $startTime: DateTime = null, $ownerAffiliations: [RepositoryAffiliation]) {
+const GRAPHQL_COUNTS_QUERY = `
+  query userInfo($login: String!, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!) {
     user(login: $login) {
       name
       login
-      commits: contributionsCollection (from: $startTime) {
-        totalCommitContributions,
-      }
-      reviews: contributionsCollection {
-        totalPullRequestReviewContributions
-      }
-      repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
-        totalCount
-      }
       pullRequests(first: 1) {
         totalCount
       }
@@ -70,29 +61,115 @@ const GRAPHQL_STATS_QUERY = `
       repositoryDiscussionComments(onlyAnswers: true) @include(if: $includeDiscussionsAnswers) {
         totalCount
       }
-      ${GRAPHQL_REPOS_FIELD}
+    }
+  }
+`;
+
+const GRAPHQL_COMMITS_QUERY = `
+  query userInfo($login: String!, $startTime: DateTime = null) {
+    user(login: $login) {
+      commits: contributionsCollection (from: $startTime) {
+        totalCommitContributions
+      }
+    }
+  }
+`;
+
+const GRAPHQL_REVIEWS_QUERY = `
+  query userInfo($login: String!) {
+    user(login: $login) {
+      reviews: contributionsCollection {
+        totalPullRequestReviewContributions
+      }
+    }
+  }
+`;
+
+const GRAPHQL_CONTRIBUTED_QUERY = `
+  query userInfo($login: String!) {
+    user(login: $login) {
+      repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
+        totalCount
+      }
     }
   }
 `;
 
 /**
- * Stats fetcher object.
+ * Build a fetcher for the given GraphQL query.
  *
- * @param {object & { after: string | null }} variables Fetcher variables.
- * @param {string} token GitHub token.
- * @returns {Promise<import('axios').AxiosResponse>} Axios response.
+ * @param {string} query GraphQL query.
+ * @returns {(variables: object, token: string) => Promise<import('axios').AxiosResponse>} Fetcher.
  */
-const fetcher = (variables, token) => {
-  const query = variables.after ? GRAPHQL_REPOS_QUERY : GRAPHQL_STATS_QUERY;
-  return request(
-    {
-      query,
-      variables,
-    },
-    {
-      Authorization: `bearer ${token}`,
-    },
-  );
+const queryFetcher =
+  (query) =>
+  (variables, token) => {
+    return request(
+      {
+        query,
+        variables,
+      },
+      {
+        Authorization: `bearer ${token}`,
+      },
+    );
+  };
+
+const countsFetcher = queryFetcher(GRAPHQL_COUNTS_QUERY);
+const commitsFetcher = queryFetcher(GRAPHQL_COMMITS_QUERY);
+const reviewsFetcher = queryFetcher(GRAPHQL_REVIEWS_QUERY);
+const contributedFetcher = queryFetcher(GRAPHQL_CONTRIBUTED_QUERY);
+const reposFetcher = queryFetcher(GRAPHQL_REPOS_QUERY);
+
+/**
+ * Fetch the user's repositories, paginating while stars remain to be counted.
+ *
+ * @param {string} username GitHub username.
+ * @param {string[]} ownerAffiliations Owner affiliations to filter by.
+ * @param {string | null} pat PAT override or null.
+ * @returns {Promise<import('axios').AxiosResponse | { totalCount: number, nodes: object[] }>} Aggregated repositories, or the errored response.
+ *
+ * @description Supports multi-page fetching if the 'FETCH_MULTI_PAGE_STARS' environment variable is set to true or a limit of fetches.
+ */
+const fetchRepositories = async (username, ownerAffiliations, pat) => {
+  const repositories = { totalCount: 0, nodes: [] };
+  let hasNextPage = true;
+  let endCursor = null;
+  let fetchedPages = 0;
+  while (hasNextPage) {
+    const res = await retryer(
+      reposFetcher,
+      {
+        login: username,
+        after: endCursor,
+        ownerAffiliations,
+      },
+      pat,
+    );
+    if (res.data.errors) {
+      return res;
+    }
+
+    const page = res.data.data.user.repositories;
+    repositories.totalCount = page.totalCount;
+    repositories.nodes.push(...page.nodes);
+
+    // Disable multi page fetching on public Vercel instance due to rate limits.
+    fetchedPages++;
+    const repoNodesWithStars = page.nodes.filter(
+      (node) => node.stargazers.totalCount !== 0,
+    );
+
+    hasNextPage =
+      (getConfig().fetchMultiPageStars === "true" ||
+        getConfig().fetchMultiPageStars > fetchedPages) &&
+      page.nodes.length === repoNodesWithStars.length &&
+      page.pageInfo.hasNextPage;
+
+    endCursor = page.pageInfo.endCursor;
+  }
+
+  return repositories;
 };
 
 /**
@@ -107,8 +184,6 @@ const fetcher = (variables, token) => {
  * @param {string[]} variables.ownerAffiliations The owner affiliations to filter by. Default: OWNER.
  * @param {string | null} variables.pat PAT override or null.
  * @returns {Promise<import('axios').AxiosResponse>} Axios response.
- *
- * @description This function supports multi-page fetching if the 'FETCH_MULTI_PAGE_STARS' environment variable is set to true or a limit of fetches.
  */
 const statsFetcher = async ({
   username,
@@ -119,55 +194,55 @@ const statsFetcher = async ({
   ownerAffiliations,
   pat,
 }) => {
-  let stats;
-  let hasNextPage = true;
-  let endCursor = null;
-  let fetchedPages = 0;
-  while (hasNextPage) {
-    const variables = {
+  const stats = await retryer(
+    countsFetcher,
+    {
       login: username,
-      first: 100,
-      after: endCursor,
       includeMergedPullRequests,
       includeDiscussions,
       includeDiscussionsAnswers,
-      startTime,
-      ownerAffiliations,
-    };
-    let res = await retryer(fetcher, variables, pat);
-    if (res.data.errors) {
-      return res;
-    }
-
-    // Store stats data.
-    const repoNodes = res.data.data.user.repositories.nodes;
-    if (stats) {
-      if (fetchedPages === 1) {
-        // make deep copy of relevant stats fields to avoid altering the cached response object in frontend
-        stats = structuredClone({
-          data: stats.data,
-          statusText: stats.statusText,
-        });
-      }
-      stats.data.data.user.repositories.nodes.push(...repoNodes);
-    } else {
-      stats = res;
-    }
-
-    // Disable multi page fetching on public Vercel instance due to rate limits.
-    fetchedPages++;
-    const repoNodesWithStars = repoNodes.filter(
-      (node) => node.stargazers.totalCount !== 0,
-    );
-
-    hasNextPage =
-      (getConfig().fetchMultiPageStars === "true" ||
-        getConfig().fetchMultiPageStars > fetchedPages) &&
-      repoNodes.length === repoNodesWithStars.length &&
-      res.data.data.user.repositories.pageInfo.hasNextPage;
-
-    endCursor = res.data.data.user.repositories.pageInfo.endCursor;
+    },
+    pat,
+  );
+  if (stats.data.errors) {
+    return stats;
   }
+  const user = stats.data.data.user;
+
+  const commits = await retryer(
+    commitsFetcher,
+    { login: username, startTime },
+    pat,
+  );
+  if (commits.data.errors) {
+    return commits;
+  }
+  user.commits = commits.data.data.user.commits;
+
+  const reviews = await retryer(reviewsFetcher, { login: username }, pat);
+  if (reviews.data.errors) {
+    return reviews;
+  }
+  user.reviews = reviews.data.data.user.reviews;
+
+  const contributed = await retryer(
+    contributedFetcher,
+    { login: username },
+    pat,
+  );
+  user.repositoriesContributedTo = contributed.data.errors
+    ? null
+    : contributed.data.data.user.repositoriesContributedTo;
+
+  const repositories = await fetchRepositories(
+    username,
+    ownerAffiliations,
+    pat,
+  );
+  if (repositories.data?.errors) {
+    return repositories;
+  }
+  user.repositories = repositories;
 
   return stats;
 };
@@ -442,7 +517,9 @@ const fetchStats = async (
     stats.totalDiscussionsAnswered =
       user.repositoryDiscussionComments.totalCount;
   }
-  stats.contributedTo = user.repositoriesContributedTo.totalCount;
+  stats.contributedTo = user.repositoriesContributedTo
+    ? user.repositoriesContributedTo.totalCount
+    : null;
 
   // Retrieve stars while filtering out repositories to be hidden.
   const allExcludedRepos = [

--- a/packages/core/src/fetchers/types.d.ts
+++ b/packages/core/src/fetchers/types.d.ts
@@ -40,7 +40,7 @@ export interface StatsData {
   totalStars: number;
   totalDiscussionsStarted: number;
   totalDiscussionsAnswered: number;
-  contributedTo: number;
+  contributedTo: number | null;
   totalPRsAuthored: number;
   totalPRsCommented: number;
   totalPRsReviewed: number;

--- a/packages/core/tests/fetchStats.test.js
+++ b/packages/core/tests/fetchStats.test.js
@@ -63,13 +63,33 @@ const data_repo = {
   data: {
     user: {
       repositories: {
+        totalCount: 5,
+        nodes: [
+          { name: "test-repo-1", stargazers: { totalCount: 100 } },
+          { name: "test-repo-2", stargazers: { totalCount: 100 } },
+          { name: "test-repo-3", stargazers: { totalCount: 100 } },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+          endCursor: "cursor",
+        },
+      },
+    },
+  },
+};
+
+const data_repo_page2 = {
+  data: {
+    user: {
+      repositories: {
+        totalCount: 5,
         nodes: [
           { name: "test-repo-4", stargazers: { totalCount: 50 } },
           { name: "test-repo-5", stargazers: { totalCount: 50 } },
         ],
         pageInfo: {
           hasNextPage: false,
-          endCursor: "cursor",
+          endCursor: "cursor2",
         },
       },
     },
@@ -80,6 +100,7 @@ const data_repo_zero_stars = {
   data: {
     user: {
       repositories: {
+        totalCount: 5,
         nodes: [
           { name: "test-repo-1", stargazers: { totalCount: 100 } },
           { name: "test-repo-2", stargazers: { totalCount: 100 } },
@@ -115,6 +136,9 @@ beforeEach(() => {
   mock.onPost("https://api.github.com/graphql").reply((cfg) => {
     let req = JSON.parse(cfg.data);
 
+    if (req.query.includes("stargazers")) {
+      return [200, req.variables.after ? data_repo_page2 : data_repo];
+    }
     if (
       req.variables &&
       req.variables.startTime &&
@@ -122,10 +146,7 @@ beforeEach(() => {
     ) {
       return [200, data_year2003];
     }
-    return [
-      200,
-      req.query.includes("totalCommitContributions") ? data_stats : data_repo,
-    ];
+    return [200, data_stats];
   });
 });
 
@@ -170,11 +191,13 @@ describe("Test fetchStats", () => {
 
   it("should stop fetching when there are repos with zero stars", async () => {
     mock.reset();
-    mock
-      .onPost("https://api.github.com/graphql")
-      .replyOnce(200, data_stats)
-      .onPost("https://api.github.com/graphql")
-      .replyOnce(200, data_repo_zero_stars);
+    mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+      let req = JSON.parse(cfg.data);
+      if (req.query.includes("stargazers")) {
+        return [200, data_repo_zero_stars];
+      }
+      return [200, data_stats];
+    });
 
     let stats = await fetchStats("anuraghazra");
     const rank = calculateRank({
@@ -216,6 +239,34 @@ describe("Test fetchStats", () => {
     await expect(fetchStats("anuraghazra")).rejects.toThrow(
       "Could not resolve to a User with the login of 'noname'.",
     );
+  });
+
+  it("should set contributedTo to null when repositoriesContributedTo exceeds resource limits", async () => {
+    mock.reset();
+    mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+      let req = JSON.parse(cfg.data);
+      if (req.query.includes("repositoriesContributedTo")) {
+        return [
+          200,
+          {
+            data: { user: null },
+            errors: [
+              {
+                type: "RESOURCE_LIMITS_EXCEEDED",
+                message: "Resource limits for this query exceeded.",
+              },
+            ],
+          },
+        ];
+      }
+      if (req.query.includes("stargazers")) {
+        return [200, data_repo];
+      }
+      return [200, data_stats];
+    });
+
+    let stats = await fetchStats("anuraghazra");
+    expect(stats.contributedTo).toBeNull();
   });
 
   it("should fetch total commits", async () => {

--- a/packages/core/tests/renderStatsCard.test.js
+++ b/packages/core/tests/renderStatsCard.test.js
@@ -59,6 +59,13 @@ describe("Test renderStatsCard", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should omit the contribs row when contributedTo is null", () => {
+    document.body.innerHTML = renderStatsCard({ ...stats, contributedTo: null });
+
+    expect(queryByTestId(document.body, "contribs")).not.toBeInTheDocument();
+    expect(getByTestId(document.body, "stars").textContent).toBe("100");
+  });
+
   it("should have proper name apostrophe", () => {
     document.body.innerHTML = renderStatsCard({ ...stats, name: "Anil Das" });
 


### PR DESCRIPTION
Fixes #373 

This avoids using a single GraphQL that can become expensive for specific users with lots of contribution activity. 

The biggest issue I found for me was that the `repositoriesContributedTo` was too expensive for GraphQL to return data. So this PR omits that metric from the view when it's unavailable, since it does not factor into the scoring algorithm.