### PR TITLE
fix dropdown bugs and gradient bug

### DIFF
--- a/apps/frontend/e2e/stats-rank.spec.ts
+++ b/apps/frontend/e2e/stats-rank.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test("selecting 'None' progress style hides the rank circle", async ({
+  page,
+}) => {
+  await page.goto("");
+
+  // Stage 0 -> 2: go to customization
+  await page.getByRole("button", { name: "Modify Parameters" }).click();
+  await expect(page.getByRole("heading", { level: 1 })).toContainText(
+    "Modify Card Parameters",
+  );
+
+  const preview = page.locator("#svgWrapper");
+  const rankCircle = preview.locator('[data-testid="rank-circle"]');
+
+  // Default "Rank" progress style renders the rank circle.
+  await expect(preview).toBeAttached();
+  await expect(rankCircle).toHaveCount(1);
+
+  await page.getByRole("combobox").selectOption({ label: "None" });
+
+  await expect(rankCircle).toHaveCount(0);
+});

--- a/apps/frontend/src/components/Home/LanguagesLayoutSection.tsx
+++ b/apps/frontend/src/components/Home/LanguagesLayoutSection.tsx
@@ -42,7 +42,7 @@ const options: Array<SelectOption> = [
     id: 6,
     label: "Only Languages",
     disabled: false,
-    value: "compact&hide_progress=true",
+    value: "hide_progress",
   },
 ];
 

--- a/apps/frontend/src/components/Home/StatsRankSection.tsx
+++ b/apps/frontend/src/components/Home/StatsRankSection.tsx
@@ -16,7 +16,7 @@ const options: Array<SelectOption> = [
   DEFAULT_OPTION,
   { id: 2, label: "Percentile", value: "percentile", disabled: false },
   { id: 3, label: "GitHub", value: "github", disabled: false },
-  { id: 4, label: "None", value: "default&hide_rank=true", disabled: false },
+  { id: 4, label: "None", value: "hide_rank", disabled: false },
 ];
 
 interface StatsRankSectionProps {

--- a/apps/frontend/src/components/Home/WakatimeLayoutSection.tsx
+++ b/apps/frontend/src/components/Home/WakatimeLayoutSection.tsx
@@ -24,7 +24,7 @@ const options: Array<SelectOption> = [
     id: 3,
     label: "Text Only",
     disabled: false,
-    value: "default&hide_progress=true&card_width=315",
+    value: "hide_progress",
   },
 ];
 

--- a/apps/frontend/src/models/CardUrl.ts
+++ b/apps/frontend/src/models/CardUrl.ts
@@ -16,11 +16,13 @@ import { CardType } from "./CardType";
  * | hide_title              |   ✓   |     ✓     |     |      |    ✓     |
  * | custom_title            |   ✓   |           |     |      |    ✓     |
  * | rank_icon               |   ✓   |           |     |      |          |
+ * | hide_rank               |   ✓   |           |     |      |          |
  * | show                    |   ✓   |           |     |      |          |
  * | show_icons              |   ✓   |           |     |      |          |
  * | include_all_commits     |   ✓   |           |     |      |          |
  * | hide_values             |       |     ✓     |     |      |          |
  * | layout                  |       |     ✓     |     |      |    ✓     |
+ * | hide_progress           |       |     ✓     |     |      |    ✓     |
  * | langs_count             |       |     ✓     |     |      |    ✓     |
  * | repo                    |       |           |  ✓  |      |          |
  * | description_lines_count |       |           |  ✓  |      |          |
@@ -107,6 +109,9 @@ class StatsCardUrl extends CardUrlBase<StatsCardUrl> {
   rankIcon(v: string) {
     return this.with("rank_icon", v);
   }
+  hideRank(v = true) {
+    return this.with("hide_rank", v);
+  }
   hideTitle(v = true) {
     return this.with("hide_title", v);
   }
@@ -142,6 +147,9 @@ class TopLangsCardUrl extends CardUrlBase<TopLangsCardUrl> {
   }
   layout(v: string) {
     return this.with("layout", v);
+  }
+  hideProgress(v = true) {
+    return this.with("hide_progress", v);
   }
   hideTitle(v = true) {
     return this.with("hide_title", v);
@@ -220,6 +228,9 @@ class WakatimeCardUrl extends CardUrlBase<WakatimeCardUrl> {
   }
   layout(v: string) {
     return this.with("layout", v);
+  }
+  hideProgress(v = true) {
+    return this.with("hide_progress", v);
   }
   hideTitle(v = true) {
     return this.with("hide_title", v);

--- a/apps/frontend/src/pages/Home/buildCardUrl.ts
+++ b/apps/frontend/src/pages/Home/buildCardUrl.ts
@@ -40,7 +40,11 @@ export function buildCardUrl(
         url = url.username(selectedUserId);
       }
       if (selectedStatsRank !== STATS_DEFAULT_RANK) {
-        url = url.rankIcon(selectedStatsRank.value);
+        if (selectedStatsRank.value === "hide_rank") {
+          url = url.hideRank();
+        } else {
+          url = url.rankIcon(selectedStatsRank.value);
+        }
       }
       if (!showTitle) {
         url = url.hideTitle();
@@ -71,7 +75,11 @@ export function buildCardUrl(
         url = url.username(selectedUserId);
       }
       if (selectedLanguagesLayout !== LANGUAGES_DEFAULT_LAYOUT) {
-        url = url.layout(selectedLanguagesLayout.value);
+        if (selectedLanguagesLayout.value === "hide_progress") {
+          url = url.hideProgress();
+        } else {
+          url = url.layout(selectedLanguagesLayout.value);
+        }
       }
       if (!showTitle) {
         url = url.hideTitle();
@@ -136,7 +144,11 @@ export function buildCardUrl(
         url = url.username(wakatimeUser);
       }
       if (selectedWakatimeLayout !== WAKATIME_DEFAULT_LAYOUT) {
-        url = url.layout(selectedWakatimeLayout.value);
+        if (selectedWakatimeLayout.value === "hide_progress") {
+          url = url.hideProgress().cardWidth(315);
+        } else {
+          url = url.layout(selectedWakatimeLayout.value);
+        }
       }
       if (!showTitle) {
         url = url.hideTitle();

--- a/packages/core/src/cards/wakatime.js
+++ b/packages/core/src/cards/wakatime.js
@@ -400,7 +400,9 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
               progressBarColor: titleColor,
               // @ts-ignore
               progressBarBackgroundColor:
-                textColor === titleColor ? bgColor : textColor,
+                textColor === titleColor
+                  ? "#fff0" // transparent
+                  : textColor,
               hideProgress: hide_progress,
               progressBarWidth: normalizedWidth - TOTAL_TEXT_WIDTH,
             });

--- a/packages/core/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/packages/core/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -516,6 +516,192 @@ exports[`Test Render WakaTime Card > should render correctly with compact layout
     "
 `;
 
+exports[`Test Render WakaTime Card > should render correctly with gradient background 1`] = `
+"
+      <svg
+        width="495"
+        height="150"
+        viewBox="0 0 495 150"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-labelledby="descId"
+      >
+        <title id="titleId"></title>
+        <desc id="descId"></desc>
+        <style>
+          .header {
+            font: 600 18px 'Segoe UI', Ubuntu, Sans-Serif;
+            fill: #ffffff;
+            animation: fadeInAnimation 0.8s ease-in-out forwards;
+          }
+          @supports(-moz-appearance: auto) {
+            /* Selector detects Firefox */
+            .header { font-size: 15.5px; }
+          }
+          
+    
+    .stat {
+      font: 600 14px 'Segoe UI', Ubuntu, "Helvetica Neue", Sans-Serif; fill: #ffffff;
+    }
+    @supports(-moz-appearance: auto) {
+      /* Selector detects Firefox */
+      .stat { font-size:12px; }
+    }
+    .stagger {
+      opacity: 0;
+      animation: fadeInAnimation 0.3s ease-in-out forwards;
+    }
+    .not_bold { font-weight: 400 }
+    .bold { font-weight: 700 }
+  
+    @keyframes slideInAnimation {
+      from {
+        width: 0;
+      }
+      to {
+        width: calc(100%-100px);
+      }
+    }
+    @keyframes growWidthAnimation {
+      from {
+        width: 0;
+      }
+      to {
+        width: 100%;
+      }
+    }
+    .lang-name { font: 400 11px 'Segoe UI', Ubuntu, Sans-Serif; fill: #ffffff }
+    #rect-mask rect{
+      animation: slideInAnimation 1s ease-in-out forwards;
+    }
+    .lang-progress{
+      animation: growWidthAnimation 0.6s ease-in-out forwards;
+    }
+    
+
+          
+      /* Animations */
+      @keyframes scaleInAnimation {
+        from {
+          transform: translate(-5px, 5px) scale(0);
+        }
+        to {
+          transform: translate(-5px, 5px) scale(1);
+        }
+      }
+      @keyframes fadeInAnimation {
+        from {
+          opacity: 0;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+    
+          
+        </style>
+
+        
+        <defs>
+          <linearGradient
+            id="gradient"
+            gradientTransform="rotate(35)"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop offset="0%" stop-color="#4158d0" />,<stop offset="50%" stop-color="#c850c0" />,<stop offset="100%" stop-color="#ffcc70" />
+          </linearGradient>
+        </defs>
+        
+
+        <rect
+          data-testid="card-bg"
+          x="0.5"
+          y="0.5"
+          rx="4.5"
+          height="99%"
+          stroke="#e4e2e2"
+          width="494"
+          fill="url(#gradient)"
+          stroke-opacity="1"
+        />
+
+        
+      <g
+        data-testid="card-title"
+        transform="translate(25, 35)"
+      >
+        <g transform="translate(0, 0)">
+      <text
+        x="0"
+        y="0"
+        class="header"
+        data-testid="header"
+      >WakaTime Stats (last 7 days)</text>
+    </g>
+      </g>
+    
+
+        <g
+          data-testid="main-card-body"
+          transform="translate(0, 55)"
+        >
+          
+    <svg x="0" y="0" width="100%">
+      <g transform="translate(0, 0)">
+    <g class="stagger" style="animation-delay: 450ms" transform="translate(25, 0)">
+      <text class="stat bold" y="12.5" data-testid="Other">Other:</text>
+      <text
+        class="stat"
+        x="350"
+        y="12.5"
+      >19 mins</text>
+      
+    <svg width="220" x="110" y="4">
+      <rect data-testid="progress-background" rx="5" ry="5" x="0" y="0" width="220" height="8" fill="#fff0"></rect>
+      <svg data-testid="lang-progress" width="47.39%">
+        <rect
+            height="8"
+            fill="#ffffff"
+            rx="5" ry="5" x="0" y="0"
+            class="lang-progress"
+            style="animation-delay: 750ms;"
+        />
+      </svg>
+    </svg>
+  
+    </g>
+  </g><g transform="translate(0, 25)">
+    <g class="stagger" style="animation-delay: 600ms" transform="translate(25, 0)">
+      <text class="stat bold" y="12.5" data-testid="TypeScript">TypeScript:</text>
+      <text
+        class="stat"
+        x="350"
+        y="12.5"
+      >1 min</text>
+      
+    <svg width="220" x="110" y="4">
+      <rect data-testid="progress-background" rx="5" ry="5" x="0" y="0" width="220" height="8" fill="#fff0"></rect>
+      <svg data-testid="lang-progress" width="50.48%">
+        <rect
+            height="8"
+            fill="#ffffff"
+            rx="5" ry="5" x="0" y="0"
+            class="lang-progress"
+            style="animation-delay: 900ms;"
+        />
+      </svg>
+    </svg>
+  
+    </g>
+  </g>
+    </svg>
+  
+        </g>
+      </svg>
+    "
+`;
+
 exports[`Test Render WakaTime Card > should render correctly with percent display format 1`] = `
 "
       <svg

--- a/packages/core/tests/renderWakatimeCard.test.js
+++ b/packages/core/tests/renderWakatimeCard.test.js
@@ -91,6 +91,13 @@ describe("Test Render WakaTime Card", () => {
     });
     expect(card).toMatchSnapshot();
   });
+
+  it("should render correctly with gradient background", () => {
+    const card = renderWakatimeCard(wakaTimeData.data, {
+      theme: "ambient_gradient",
+    });
+    expect(card).toMatchSnapshot();
+  });
 });
 
 describe("test wakatime API", () => {


### PR DESCRIPTION
* In the frontend, "Modify Parameters" step, a few options of several dropdowns encoded multiple parameters in their value string. That didn't work anymore since a recent change. This PR fixes the affected dropdown options.
* Since a recent change, using the "ambient_gradient" theme for WakaTime card didn't work anymore. This PR fixes that.