### PR TITLE
feat(core): align repo star field naming and add type coverage

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,8 +1,11 @@
 {
   "$schema": "./node_modules/knip/schema.json",
+  "vitest": {
+    "entry": ["tests/**/*.{test,test-d,bench}.{js,ts}"]
+  },
   "workspaces": {
     "apps/backend": {
-      "entry": ["api-renamed/*.js", "express.js", "tests/bench/*.bench.js"]
+      "entry": ["api-renamed/*.js", "express.js"]
     },
     "apps/frontend": {
       "entry": ["src/wakatime-override.ts"]

--- a/packages/core/src/cards/repo.js
+++ b/packages/core/src/cards/repo.js
@@ -76,7 +76,7 @@ const renderRepoCard = (repo, options = {}) => {
     primaryLanguage,
     isArchived,
     isTemplate,
-    starCount,
+    stargazerCount,
     forkCount,
     totalPRsAuthored,
     totalPRsCommented,
@@ -263,7 +263,7 @@ const renderRepoCard = (repo, options = {}) => {
     ? createLanguageNode(langName, langColor)
     : "";
 
-  const totalStars = kFormatter(starCount);
+  const totalStars = kFormatter(stargazerCount);
   const totalForks = kFormatter(forkCount);
   const svgStars = iconWithLabel(
     icons.star,

--- a/packages/core/src/fetchers/repo.ts
+++ b/packages/core/src/fetchers/repo.ts
@@ -144,7 +144,6 @@ const fetchRepo = async (
     return {
       ...repoUserStats,
       ...repository,
-      stargazerCount: repository.stargazerCount,
     };
   }
 
@@ -167,7 +166,6 @@ const fetchRepo = async (
     return {
       ...repoUserStats,
       ...repository,
-      stargazerCount: repository.stargazerCount,
     };
   }
 

--- a/packages/core/src/fetchers/repo.ts
+++ b/packages/core/src/fetchers/repo.ts
@@ -5,7 +5,7 @@ import { request } from "../common/http.js";
 import { retryer } from "../common/retryer.js";
 
 import { fetchRepoUserStats } from "./stats.js";
-import type { RepositoryData } from "./types.js";
+import type { RepoInfo, RepositoryData } from "./types.js";
 
 /**
  * Repo data fetcher.
@@ -58,19 +58,6 @@ const fetcher = (
 };
 
 const urlExample = "/api/pin?username=USERNAME&repo=REPO_NAME";
-
-/** A repository as selected by the `RepoInfo` fragment above. */
-interface RepoInfo {
-  name: string;
-  nameWithOwner: string;
-  isPrivate: boolean;
-  isArchived: boolean;
-  isTemplate: boolean;
-  stargazerCount: number;
-  description: string;
-  primaryLanguage: { color: string; id: string; name: string };
-  forkCount: number;
-}
 
 /** Shape of `response.data` returned by the repo query. */
 interface RepoQueryResponse {
@@ -157,7 +144,7 @@ const fetchRepo = async (
     return {
       ...repoUserStats,
       ...repository,
-      starCount: repository.stargazerCount,
+      stargazerCount: repository.stargazerCount,
     };
   }
 
@@ -180,7 +167,7 @@ const fetchRepo = async (
     return {
       ...repoUserStats,
       ...repository,
-      starCount: repository.stargazerCount,
+      stargazerCount: repository.stargazerCount,
     };
   }
 

--- a/packages/core/src/fetchers/stats.ts
+++ b/packages/core/src/fetchers/stats.ts
@@ -11,7 +11,7 @@ import { logger } from "../common/log.js";
 import { buildSearchFilter, parseOwnerAffiliations } from "../common/ops.js";
 import { retryer } from "../common/retryer.js";
 
-import type { StatsData } from "./types.js";
+import type { RepoUserStats, StatsData } from "./types.js";
 
 // GraphQL queries.
 const GRAPHQL_REPOS_FIELD = `
@@ -109,15 +109,6 @@ interface StatsFetcherResponse {
     errors?: Array<{ type?: string; message?: string }>;
   };
   statusText: string;
-}
-
-/** Per-repo/-user counts fetched via the REST search API. */
-interface RepoUserStats {
-  totalPRsAuthored?: number;
-  totalPRsCommented?: number;
-  totalPRsReviewed?: number;
-  totalIssuesAuthored?: number;
-  totalIssuesCommented?: number;
 }
 
 /**

--- a/packages/core/src/fetchers/types.ts
+++ b/packages/core/src/fetchers/types.ts
@@ -32,9 +32,7 @@ export interface RepoUserStats {
   totalIssuesCommented?: number;
 }
 
-export interface RepositoryData extends RepoInfo, RepoUserStats {
-  stargazerCount: number;
-}
+export type RepositoryData = RepoInfo & RepoUserStats;
 
 export interface StatsData {
   name: string;

--- a/packages/core/src/fetchers/types.ts
+++ b/packages/core/src/fetchers/types.ts
@@ -7,7 +7,7 @@ export interface GistData {
   forksCount: number;
 }
 
-export interface RepositoryData {
+export interface RepoInfo {
   name: string;
   nameWithOwner: string;
   isPrivate: boolean;
@@ -21,13 +21,19 @@ export interface RepositoryData {
     name: string;
   };
   forkCount: number;
-  starCount: number;
+}
+
+export interface RepoUserStats {
   // only present when the matching include_* flag is set (see fetchRepoUserStats)
   totalPRsAuthored?: number;
   totalPRsCommented?: number;
   totalPRsReviewed?: number;
   totalIssuesAuthored?: number;
   totalIssuesCommented?: number;
+}
+
+export interface RepositoryData extends RepoInfo, RepoUserStats {
+  stargazerCount: number;
 }
 
 export interface StatsData {

--- a/packages/core/tests/fetchRepo.test.ts
+++ b/packages/core/tests/fetchRepo.test.ts
@@ -46,7 +46,7 @@ describe("Test fetchRepo", () => {
 
     expect(repo).toStrictEqual({
       ...data_repo.repository,
-      starCount: data_repo.repository.stargazerCount,
+      stargazerCount: data_repo.repository.stargazerCount,
     });
   });
 
@@ -56,7 +56,7 @@ describe("Test fetchRepo", () => {
     const repo = await fetchRepo("anuraghazra", "convoychat");
     expect(repo).toStrictEqual({
       ...data_repo.repository,
-      starCount: data_repo.repository.stargazerCount,
+      stargazerCount: data_repo.repository.stargazerCount,
     });
   });
 

--- a/packages/core/tests/fetchRepo.test.ts
+++ b/packages/core/tests/fetchRepo.test.ts
@@ -44,20 +44,14 @@ describe("Test fetchRepo", () => {
 
     const repo = await fetchRepo("anuraghazra", "convoychat");
 
-    expect(repo).toStrictEqual({
-      ...data_repo.repository,
-      stargazerCount: data_repo.repository.stargazerCount,
-    });
+    expect(repo).toStrictEqual(data_repo.repository);
   });
 
   it("should fetch correct org repo", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, data_org);
 
     const repo = await fetchRepo("anuraghazra", "convoychat");
-    expect(repo).toStrictEqual({
-      ...data_repo.repository,
-      stargazerCount: data_repo.repository.stargazerCount,
-    });
+    expect(repo).toStrictEqual(data_repo.repository);
   });
 
   it("should throw error if user is found but repo is null", async () => {

--- a/packages/core/tests/fetchRepo.types.test-d.ts
+++ b/packages/core/tests/fetchRepo.types.test-d.ts
@@ -1,0 +1,31 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { RepoUserStats, RepositoryData } from "../src/fetchers/types.js";
+
+describe("repo fetcher types", () => {
+  it("should expose shared repo stats typing", () => {
+    const stats: RepoUserStats = { totalPRsAuthored: 2 };
+
+    const repoData: RepositoryData = {
+      name: "convoychat",
+      nameWithOwner: "anuraghazra/convoychat",
+      isPrivate: false,
+      isArchived: false,
+      isTemplate: false,
+      stargazerCount: 38000,
+      description: "Help us take over the world!",
+      primaryLanguage: {
+        color: "#2b7489",
+        id: "MDg6TGFuZ3VhZ2UyODc=",
+        name: "TypeScript",
+      },
+      forkCount: 100,
+      ...(stats.totalPRsAuthored === undefined
+        ? {}
+        : { totalPRsAuthored: stats.totalPRsAuthored }),
+    };
+
+    expectTypeOf(repoData.totalPRsAuthored).toEqualTypeOf<number | undefined>();
+    expectTypeOf(repoData).toExtend<RepositoryData>();
+  });
+});

--- a/packages/core/tests/renderRepoCard.test.js
+++ b/packages/core/tests/renderRepoCard.test.js
@@ -16,7 +16,7 @@ const data_repo = {
       id: "MDg6TGFuZ3VhZ2UyODc=",
       name: "TypeScript",
     },
-    starCount: 38000,
+    stargazerCount: 38000,
     forkCount: 100,
   },
 };
@@ -279,7 +279,7 @@ describe("Test renderRepoCard", () => {
   it("should not render star count or fork count if either of the are zero", () => {
     document.body.innerHTML = renderRepoCard({
       ...data_repo.repository,
-      starCount: 0,
+      stargazerCount: 0,
     });
 
     expect(queryByTestId(document.body, "stargazers")).toBeNull();
@@ -287,7 +287,7 @@ describe("Test renderRepoCard", () => {
 
     document.body.innerHTML = renderRepoCard({
       ...data_repo.repository,
-      starCount: 1,
+      stargazerCount: 1,
       forkCount: 0,
     });
 
@@ -296,7 +296,7 @@ describe("Test renderRepoCard", () => {
 
     document.body.innerHTML = renderRepoCard({
       ...data_repo.repository,
-      starCount: 0,
+      stargazerCount: 0,
       forkCount: 0,
     });
 

--- a/packages/core/tests/xss.test.js
+++ b/packages/core/tests/xss.test.js
@@ -27,7 +27,7 @@ vi.mock("../src/fetchers/repo.js", () => ({
       id: "<script>alert('xss')</script>",
       name: "<script>alert('xss')</script>",
     },
-    starCount: 38000,
+    stargazerCount: 38000,
     forkCount: 100,
   }),
 }));


### PR DESCRIPTION
Followup of https://github.com/stats-organization/github-stats-extended/pull/426#discussion_r3695160068

> Now that we have `RepoInfo`, would it make sense to define `RepositoryData` as combination of `RepoInfo` and `RepoUserStats` (and align the naming of "starCount"/"stargazerCount") in a later PR?