### PR TITLE
Add thousand separator for long numeric output type

### DIFF
--- a/packages/core/src/cards/stats.js
+++ b/packages/core/src/cards/stats.js
@@ -102,7 +102,7 @@ const createTextNode = ({
       : undefined;
   const kValue =
     numberFormat.toLowerCase() === "long" || id === "prs_merged_percentage"
-      ? value
+      ? value.toLocaleString()
       : kFormatter(value, precision);
   const staggerDelay = (index + 3) * 150;
 


### PR DESCRIPTION
Add thousand separator for long numeric output type for example 1,234 instead of 1234