### PR TITLE
docs: explain the Backend E2E failure and refine docs content

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ pnpm run lint       # eslint
 pnpm run typecheck  # tsc
 ```
 
-The **Backend E2E test** in CI compares the cards your branch renders against the ones served by the preview deployment, which is still on the last commit merged to main.
+The **Backend E2E test** in CI compares the cards your branch renders against the ones served by the preview deployment, which is still on the last commit merged to master.
 So if your PR changes card output at all, that job goes red until the preview catches up.
 It's marked `continue-on-error`, so it won't block your PR, but do open it and check the diff is only what you expected.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,6 +12,25 @@ pnpm run dev:frontend
 
 The easiest way to run and test the project is to deploy it to Vercel as described in the [deployment guide](../docs/deploy.md).
 
+## Tests
+
+```bash
+pnpm run test       # unit tests
+pnpm run lint       # eslint
+pnpm run typecheck  # tsc
+```
+
+The **Backend E2E test** in CI compares the cards your branch renders against the ones served by the preview deployment, which is still on the last commit merged to main.
+So if your PR changes card output at all, that job goes red until the preview catches up.
+It's marked `continue-on-error`, so it won't block your PR, but do open it and check the diff is only what you expected.
+
+If the change to card markup was intentional, update the snapshots:
+
+```bash
+pnpm --filter ./packages/core/ run test:update:snapshot
+pnpm --filter ./apps/backend/ run test:update:snapshot
+```
+
 ## Themes Contribution
 
 We have stopped the addition of new themes to decrease maintenance efforts. If you are considering contributing your theme just because you are using it personally, then instead of adding it to our theme collection, you can use card [customization options](../docs/advanced_documentation.md#customization).
@@ -30,25 +49,7 @@ In short, when you submit changes, your submissions are understood to be under t
 
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/stats-organization/github-stats-extended/issues/new/choose). If there is already an open issue for your bug in the upstream repo [github-readme-stats](https://github.com/anuraghazra/github-readme-stats/issues) you don't need to report it here.
 
-## Frequently Asked Questions (FAQs)
-
-**Q:** How to hide Jupyter Notebook?
-
-> **Ans:** &hide=jupyter%20notebook
-
-**Q:** Language Card is incorrect
-
-> **Ans:** Please read all the related issues/comments before opening any issues regarding language card stats:
->
-> - <https://github.com/anuraghazra/github-readme-stats/issues/136#issuecomment-665164174>
->
-> - <https://github.com/anuraghazra/github-readme-stats/issues/136#issuecomment-665172181>
-
-**Q:** How to count private stats?
-
-> see [here](../docs/fork.md#private-contributions-support)
-
-### Feature Request
+## Feature Request
 
 **Great Feature Requests** tend to have:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       contents: read
 
     # Compares the cards we render here against the preview deployment,
-    # which is still on the last commit merged on main.
+    # which is still on the last commit merged on master.
     # So any PR that changes card output turns this red until the preview catches up.
     # Worth a look, just not always a bug.
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
     permissions:
       contents: read
 
+    # Compares the cards we render here against the preview deployment,
+    # which is still on the last commit merged on main.
+    # So any PR that changes card output turns this red until the preview catches up.
+    # Worth a look, just not always a bug.
     continue-on-error: true
 
     steps:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 This project is the [extended, actively maintained successor](docs/fork.md) of [github-readme-stats](https://github.com/anuraghazra/github-readme-stats). It generates [various stats cards](#card-types), e.g. about your GitHub contributions, your top languages, etc. You can [customize](#advanced-customization) the cards via multiple parameters.
 
-# Table of Contents
+## Table of Contents
+
 - [Quick Start](#quick-start)
 - [Migration from github-readme-stats](#migration-from-github-readme-stats)
 - [Card Types](#card-types)
@@ -16,7 +17,8 @@ This project is the [extended, actively maintained successor](docs/fork.md) of [
 - [Acknowledgements](#acknowledgements)
 - [Contributing](#contributing)
 
-# Quick Start
+## Quick Start
+
 - Copy and paste this into your markdown:
   ```markdown
   [![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra)](https://github.com/stats-organization/github-stats-extended)
@@ -28,7 +30,8 @@ This project is the [extended, actively maintained successor](docs/fork.md) of [
 
 As more comfortable alternative, use the [GitHub-Stats-Extended Wizard](https://github-stats-extended.vercel.app/frontend) to create your custom stats card. Copy the generated markdown code and paste it into your [GitHub profile README](https://docs.github.com/en/account-and-profile/how-tos/profile-customization/managing-your-profile-readme#adding-a-profile-readme). Done!
 
-# Migration from github-readme-stats
+## Migration from github-readme-stats
+
 To migrate from [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) you only need to change the domain from `github-readme-stats.vercel.app` to `github-stats-extended.vercel.app`:
 
 ```diff
@@ -38,7 +41,8 @@ To migrate from [github-readme-stats](https://github.com/anuraghazra/github-read
 
 GitHub-Stats-Extended aims to be fully compatible with github-readme-stats. For more details see [Compatibility Notes](docs/fork.md#compatibility-notes).
 
-# Card Types
+## Card Types
+
 - Show your GitHub statistics:
 
   ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra)
@@ -63,16 +67,20 @@ GitHub-Stats-Extended aims to be fully compatible with github-readme-stats. For 
 
   [![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api/?username=anuraghazra&show_icons=true&theme=calm&rank_icon=github&include_all_commits=true&custom_title=Anurag's+Stats&disable_animations=true&number_format=long&show=prs_merged_percentage,prs_reviewed)](https://github-stats-extended.vercel.app/api/?username=anuraghazra&show_icons=true&theme=calm&rank_icon=github&include_all_commits=true&custom_title=Anurag's+Stats&disable_animations=true&number_format=long&show=prs_merged_percentage,prs_reviewed)
 
-# Advanced Customization
+## Advanced Customization
+
 The [GitHub-Stats-Extended Wizard](https://github-stats-extended.vercel.app/frontend) offers some essential customization options. For more advanced customization check out the [advanced documentation](docs/advanced_documentation.md).
 
-# Run It Yourself
+## Run It Yourself
+
 If you want to run GitHub-Stats-Extended on your own, there are two main deployment options: you can use [github-readme-stats-action](https://github.com/stats-organization/github-readme-stats-action) to generate cards in your own GitHub Actions workflow. Or you can self-host GitHub-Stats-Extended on Vercel.
 
 See [Run It Yourself](docs/deploy.md) for detailed instructions.
 
-# Acknowledgements
+## Acknowledgements
+
 This project is based on [github-readme-stats](https://github.com/anuraghazra/github-readme-stats). On top of that project's functionality GitHub-Stats-Extended adds several new features and improvements. See [Fork Information](docs/fork.md) for a list of changes. The frontend added to GitHub-Stats-Extended is based on [GitHub Trends](https://github.com/avgupta456/github-trends). Big thanks to [@anuraghazra](https://github.com/anuraghazra), [@avgupta456](https://github.com/avgupta456), [@rickstaa](https://github.com/rickstaa), [@qwerty541](https://github.com/qwerty541) and everyone else who worked on these projects! ❤️
 
-# Contributing
+## Contributing
+
 Contributions are welcome!

--- a/docs/advanced_documentation.md
+++ b/docs/advanced_documentation.md
@@ -429,13 +429,18 @@ ranking_index = (byte_count ^ size_weight) * (repo_count ^ count_weight)
 
 By default, only the byte count is used for determining the languages percentages shown on the language card (i.e. `size_weight=1` and `count_weight=0`). You can, however, use the `&size_weight=` and `&count_weight=` options to weight the language usage calculation. The values must be positive real numbers. [More details about the algorithm can be found here](https://github.com/anuraghazra/github-readme-stats/issues/1600#issuecomment-1046056305).
 
-*   `&size_weight=1&count_weight=0` - *(default)* Orders by byte count.
-*   `&size_weight=0.5&count_weight=0.5` - *(recommended)* Uses both byte and repo count for ranking
-    *   `&size_weight=0&count_weight=1` - Orders by repo count
+- `&size_weight=1&count_weight=0` - *(default)* Orders by byte count.
+- `&size_weight=0.5&count_weight=0.5` - *(recommended)* Uses both byte and repo count for ranking
+  - `&size_weight=0&count_weight=1` - Orders by repo count
 
 ```md
 ![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra&size_weight=0.5&count_weight=0.5)
 ```
+
+If the percentages still look wrong to you, these two comments cover most of the reasons why, and are worth reading before opening an issue:
+
+- <https://github.com/anuraghazra/github-readme-stats/issues/136#issuecomment-665164174>
+- <https://github.com/anuraghazra/github-readme-stats/issues/136#issuecomment-665172181>
 
 ### Exclude individual repositories
 
@@ -452,6 +457,8 @@ You can use `&hide=language1,language2` parameter to hide individual languages.
 ```md
 ![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra&hide=javascript,html)
 ```
+
+Language names with spaces or symbols need to be [percent-encoded](#options-2), so Jupyter Notebook becomes `&hide=jupyter%20notebook` and C++ becomes `&hide=c%2B%2B`.
 
 ### Show more languages
 
@@ -514,28 +521,27 @@ You can use the `&stats_format=bytes` option to display the stats in bytes inste
 
 ![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra)
 
-*   Compact layout
+#### Compact layout
 
 ![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&layout=compact)
 
-*   Donut Chart layout
+#### Donut Chart layout
 
 [![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&layout=donut)](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&layout=donut)
 
-*   Donut Vertical Chart layout
+#### Donut Vertical Chart layout
 
 [![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&layout=donut-vertical)](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&layout=donut-vertical)
 
-*   Pie Chart layout
+#### Pie Chart layout
 
 [![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&layout=pie)](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&layout=pie)
 
-*   Hidden progress bars
+#### Hidden progress bars
 
 [![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&hide_progress=true)](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&hide_progress=true)
 
-
-*  Display bytes instead of percentage
+#### Display bytes instead of percentage
 
 [![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&stats_format=bytes)](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra\&stats_format=bytes)
 
@@ -580,7 +586,7 @@ You can customize the appearance and behavior of the WakaTime stats card using t
 
 ![Alan's WakaTime stats](https://github-stats-extended.vercel.app/api/wakatime?username=alan\&card_width=315\&hide_progress=true)
 
-*   Compact layout
+#### Compact layout
 
 ![Alan's WakaTime stats](https://github-stats-extended.vercel.app/api/wakatime?username=alan\&layout=compact)
 
@@ -588,81 +594,81 @@ You can customize the appearance and behavior of the WakaTime stats card using t
 
 ## All Demos
 
-*   Default
+### Default
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra)
 
-*   Hiding specific stats
+### Hiding specific stats
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&hide=contribs,issues)
 
-*   Showing additional stats
+### Showing additional stats
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&show_icons=true\&show=reviews,discussions_started,discussions_answered,prs_merged,prs_merged_percentage,prs_commented,prs_reviewed,issues_commented)
 
-*   Showing stats for a specific repository
+### Showing stats for a specific repository
 
 ![Anurag's GitHub stats for anuraghazra/github-readme-stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&repo=anuraghazra/github-readme-stats\&hide=prs,issues,stars,commits,contribs\&show=prs_authored,prs_commented,prs_reviewed,issues_authored,issues_commented\&hide_rank=true\&custom_title=Anurag%27s%20Stats%20for%20github-readme-stats\&card_width=370)
 
-*   Showing stats for a specific organization
+### Showing stats for a specific organization
 
 ![Anurag's GitHub stats for razorpay](https://github-stats-extended.vercel.app/api?username=anuraghazra\&owner=razorpay\&hide=prs,issues,stars,commits,contribs\&show=prs_authored,prs_commented,prs_reviewed,issues_authored,issues_commented\&hide_rank=true\&custom_title=Anurag%27s%20Stats%20for%20razorpay\&card_width=370)
 
-*   Showing icons
+### Showing icons
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&hide=issues\&show_icons=true)
 
-*   Shows GitHub logo instead rank level
+### Shows GitHub logo instead rank level
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&rank_icon=github)
 
-*   Shows user rank percentile instead of rank level
+### Shows user rank percentile instead of rank level
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&rank_icon=percentile)
 
-*   Customize Border Color
+### Customize Border Color
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&border_color=2e4058)
 
-*   Include All Commits
+### Include All Commits
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&include_all_commits=true)
 
-*   Themes
+### Themes
 
 Choose from any of the [default themes](#themes)
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&show_icons=true\&theme=radical)
 
-*   Gradient
+### Gradient
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api?username=anuraghazra\&bg_color=30,e96443,904e95\&title_color=fff\&text_color=fff)
 
-*   Customizing stats card
+### Customizing stats card
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api/?username=anuraghazra\&show_icons=true\&title_color=fff\&icon_color=79ff97\&text_color=9f9f9f\&bg_color=151515)
 
-*   Setting card locale
+### Setting card locale
 
 ![Anurag's GitHub stats](https://github-stats-extended.vercel.app/api/?username=anuraghazra\&locale=es)
 
-*   Customizing repo card
+### Customizing repo card
 
 ![Customized Card](https://github-stats-extended.vercel.app/api/pin?username=anuraghazra\&repo=github-readme-stats\&title_color=fff\&icon_color=f9f9f9\&text_color=9f9f9f\&bg_color=151515)
 
-*   Gist card
+### Gist card
 
 ![Gist Card](https://github-stats-extended.vercel.app/api/gist?id=bbfce31e0217a3689c8d961a356cb10d)
 
-*   Customizing gist card
+### Customizing gist card
 
 ![Gist Card](https://github-stats-extended.vercel.app/api/gist?id=bbfce31e0217a3689c8d961a356cb10d&theme=calm)
 
-*   Top languages
+### Top languages
 
 ![Top Langs](https://github-stats-extended.vercel.app/api/top-langs/?username=anuraghazra)
 
-*   WakaTime card
+### WakaTime card
 
 ![Alan's WakaTime stats](https://github-stats-extended.vercel.app/api/wakatime?username=alan)
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,30 +65,30 @@ Selecting the right scopes for your token is important in case you want to displ
 
 #### Classic token
 
-* Go to [Account -> Settings -> Developer Settings -> Personal access tokens -> Tokens (classic)](https://github.com/settings/tokens).
-    * Click on `Generate new token -> Generate new token (classic)`.
-    * Scopes to select:
-        * repo
-        * read:user
-    * Click on `Generate token` and copy it.
+- Go to [Account -> Settings -> Developer Settings -> Personal access tokens -> Tokens (classic)](https://github.com/settings/tokens).
+  - Click on `Generate new token -> Generate new token (classic)`.
+  - Scopes to select:
+    - repo
+    - read:user
+  - Click on `Generate token` and copy it.
 
 #### Fine-grained token
 
 > [!WARNING]\
 > This limits the scope of commits to public repositories only.
 
-* Go to [Account -> Settings -> Developer Settings -> Personal access tokens -> Fine-grained tokens](https://github.com/settings/personal-access-tokens).
-    * Click on `Generate new token -> Generate new token`.
-    * Enter a token name
-    * Select an expiration date
-    * Select `All repositories`
-    * Scopes to select under `Permissions`:
-        * Commit statuses: read-only
-        * Contents: read-only
-        * Issues: read-only
-        * Metadata: read-only (added automatically when selecting above scopes)
-        * Pull requests: read-only
-    * Click on `Generate token` and copy it.
+- Go to [Account -> Settings -> Developer Settings -> Personal access tokens -> Fine-grained tokens](https://github.com/settings/personal-access-tokens).
+  - Click on `Generate new token -> Generate new token`.
+  - Enter a token name
+  - Select an expiration date
+  - Select `All repositories`
+  - Scopes to select under `Permissions`:
+    - Commit statuses: read-only
+    - Contents: read-only
+    - Issues: read-only
+    - Metadata: read-only (added automatically when selecting above scopes)
+    - Pull requests: read-only
+  - Click on `Generate token` and copy it.
 
 ### On Vercel
 


### PR DESCRIPTION
Related to https://github.com/stats-organization/github-stats-extended/pull/430

> [(The failing Backend E2E test is expected, because this PR changes the output of most cards, but in a non-visible way.)](https://github.com/stats-organization/github-stats-extended/pull/430#issuecomment-5153247227)

- `ci.yml`: comment explaining what the job compares and why it fails.
- `CONTRIBUTING.md`: new "Tests" section, there was no testing documentation before. 
  Removed the FAQ, whose three entries were all user questions, and promoted Feature Request from `h3` to `h2`.
- `advanced_documentation`: kept the two useful FAQ answers, in context: 
    - language-card troubleshooting links under "Language stats algorithm", 
    - percent-encoding example (`&hide=jupyter%20notebook`) under "Hide individual languages". 
  Demo labels changed from list items to `h4` headings: the images were never indented into the list, so each label rendered as its own one-item bullet.
- `deploy.md`: normalized the token-setup lists from `*` with 4 space indents to `-` with 2 space indents.
  Marker and indentation only, nesting preserved.
- `README.md`: the seven section headings were `h1`. With the HTML `<h1>` in  the banner that made eight top-level headings on one page, so they are now  `h2`. 
   Heading anchors are derived from the text, so the table of contents  is unaffected.