### PR TITLE
ci(repeat-recent-requests): replace http-request-action with curl

### DIFF
--- a/.github/workflows/repeat-recent-requests.yml
+++ b/.github/workflows/repeat-recent-requests.yml
@@ -16,7 +16,7 @@ on:
 permissions: {}
 
 jobs:
-  triggerRepeatRecent:
+  repeat-recent-requests:
     if: |
       github.repository == 'anuraghazra/github-readme-stats' ||
       github.repository == 'stats-organization/github-readme-stats' ||
@@ -25,13 +25,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Make Request
-        id: myRequest
-        uses: fjogeleit/http-request-action@f98bb26551cd1af7d3eb2674578a80754ece88db # v2
-        with:
-          url: "https://github-stats-extended.vercel.app/api/repeat-recent"
-          method: "POST"
-          timeout: "300000"
-      - name: Show Response
         run: |
-          echo ${{ steps.myRequest.outputs.response }}
-          echo ${{ steps.myRequest.outputs.status }}
+          args=(
+            --silent --show-error            # no progress bar, but still report errors
+            --request POST                   # the only thing the endpoint checks
+            --location                       # a redirect would otherwise pass the status check
+            --max-redirs 5                   # bounded well below curl's default of 50
+            --speed-limit 1 --speed-time 300 # give up after 300s of no traffic
+            --output response.txt            # keep the body out of the status capture
+            --write-out "%{http_code}"       # status is all we capture on stdout
+          )
+          status=$(curl "${args[@]}" "https://github-stats-extended.vercel.app/api/repeat-recent")
+          cat response.txt
+          printf '\nstatus: %s\n' "$status"
+          test "$status" -lt 400


### PR DESCRIPTION
- Swaps the third-party `fjogeleit/http-request-action` for a plain `curl` step in `repeat-recent-requests.yml`:
  the workflow only needs a POST with a timeout, so the action added no value.
- The request carries only what the endpoint reads. `repeat-recent` checks `req.method` and nothing else. 
  So the action's JSON body and headers were never used. 
  Each flag has a one-line comment explaining why it's there.
- Failure semantics are preserved: a `>= 400` status or a connection failure still fails the job, and the response body and status are now logged even on failure.

Example run: https://github.com/marcalexiei/github-stats-extended/actions/runs/30751117550/job/91505220151