### PR TITLE
refactor(core): derive color param names from a single source of truth

### DIFF
--- a/packages/core/src/api/gist.js
+++ b/packages/core/src/api/gist.js
@@ -1,5 +1,5 @@
 import { renderGistCard } from "../cards/gist.js";
-import { findInvalidColor, pickColorParams } from "../common/color.js";
+import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
   retrieveSecondaryMessage,
@@ -24,12 +24,7 @@ export default async (
 ) => {
   const colorParams = pickColorParams(remainingParams);
 
-  const invalidColorInput = findInvalidColor({
-    ...colorParams,
-    theme: undefined,
-    theme_light: undefined,
-    theme_dark: undefined,
-  });
+  const invalidColorInput = findInvalidColorParam(colorParams);
   if (invalidColorInput) {
     return {
       status: "error - permanent",

--- a/packages/core/src/api/index.js
+++ b/packages/core/src/api/index.js
@@ -1,5 +1,5 @@
 import { renderStatsCard } from "../cards/stats.js";
-import { findInvalidColor, pickColorParams } from "../common/color.js";
+import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
   retrieveSecondaryMessage,
@@ -41,12 +41,7 @@ export default async (
 ) => {
   const colorParams = pickColorParams(remainingParams);
 
-  const invalidColorInput = findInvalidColor({
-    ...colorParams,
-    theme: undefined,
-    theme_light: undefined,
-    theme_dark: undefined,
-  });
+  const invalidColorInput = findInvalidColorParam(colorParams);
   if (invalidColorInput) {
     return {
       status: "error - permanent",

--- a/packages/core/src/api/pin.js
+++ b/packages/core/src/api/pin.js
@@ -1,5 +1,5 @@
 import { renderRepoCard } from "../cards/repo.js";
-import { findInvalidColor, pickColorParams } from "../common/color.js";
+import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
   retrieveSecondaryMessage,
@@ -32,12 +32,7 @@ export default async (
 ) => {
   const colorParams = pickColorParams(remainingParams);
 
-  const invalidColorInput = findInvalidColor({
-    ...colorParams,
-    theme: undefined,
-    theme_light: undefined,
-    theme_dark: undefined,
-  });
+  const invalidColorInput = findInvalidColorParam(colorParams);
   if (invalidColorInput) {
     return {
       status: "error - permanent",

--- a/packages/core/src/api/top-langs.js
+++ b/packages/core/src/api/top-langs.js
@@ -1,5 +1,5 @@
 import { renderTopLanguages } from "../cards/top-languages.js";
-import { findInvalidColor, pickColorParams } from "../common/color.js";
+import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
   retrieveSecondaryMessage,
@@ -36,12 +36,7 @@ export default async (
 ) => {
   const colorParams = pickColorParams(remainingParams);
 
-  const invalidColorInput = findInvalidColor({
-    ...colorParams,
-    theme: undefined,
-    theme_light: undefined,
-    theme_dark: undefined,
-  });
+  const invalidColorInput = findInvalidColorParam(colorParams);
 
   if (invalidColorInput) {
     return {

--- a/packages/core/src/api/wakatime.js
+++ b/packages/core/src/api/wakatime.js
@@ -1,5 +1,5 @@
 import { renderWakatimeCard } from "../cards/wakatime.js";
-import { findInvalidColor, pickColorParams } from "../common/color.js";
+import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
   retrieveSecondaryMessage,
@@ -30,12 +30,7 @@ export default async ({
 }) => {
   const colorParams = pickColorParams(remainingParams);
 
-  const invalidColorInput = findInvalidColor({
-    ...colorParams,
-    theme: undefined,
-    theme_light: undefined,
-    theme_dark: undefined,
-  });
+  const invalidColorInput = findInvalidColorParam(colorParams);
   if (invalidColorInput) {
     return {
       status: "error - permanent",

--- a/packages/core/src/common/color.ts
+++ b/packages/core/src/common/color.ts
@@ -118,20 +118,33 @@ interface CardColors {
 }
 
 /**
+ * Every color param a card accepts, before any `_light` / `_dark` suffix.
+ *
+ * Single source of truth: the param types and {@link COLOR_PARAM_KEYS} are all
+ * derived from this, so adding a param here is enough.
+ */
+const BASE_COLOR_KEYS = [
+  "title_color",
+  "icon_color",
+  "text_color",
+  "bg_color",
+  "border_color",
+  "ring_color",
+  "prog_bar_bg_color",
+  "theme",
+] as const;
+
+const THEME_VARIANTS = ["light", "dark"] as const;
+
+type BaseColorKey = (typeof BASE_COLOR_KEYS)[number];
+type ThemeVariant = (typeof THEME_VARIANTS)[number];
+
+/**
  * Object with all input color params. Not every field is consumed by every card
  * (e.g. `prog_bar_bg_color` is only used by the top-languages card's `normal`
  * layout).
  */
-interface ColorInput {
-  title_color?: string | undefined;
-  text_color?: string | undefined;
-  icon_color?: string | undefined;
-  bg_color?: string | undefined;
-  border_color?: string | undefined;
-  ring_color?: string | undefined;
-  prog_bar_bg_color?: string | undefined;
-  theme?: string | undefined;
-}
+type ColorInput = Partial<Record<BaseColorKey, string | undefined>>;
 
 /**
  * Returns theme based colors with proper overrides and defaults.
@@ -224,9 +237,8 @@ const getCardColors = ({
   };
 };
 
-type ThemeVariant = "dark" | "light";
 type LightDarkColorParams = Partial<
-  Record<`${keyof ColorInput}_${ThemeVariant}`, string>
+  Record<`${BaseColorKey}_${ThemeVariant}`, string | undefined>
 >;
 
 /**
@@ -240,16 +252,10 @@ type LightDarkColorParams = Partial<
 const extractLightDarkColors = (
   params: LightDarkColorParams,
   suffix: `_${ThemeVariant}`,
-): ColorInput => ({
-  title_color: params[`title_color${suffix}`],
-  text_color: params[`text_color${suffix}`],
-  icon_color: params[`icon_color${suffix}`],
-  bg_color: params[`bg_color${suffix}`],
-  border_color: params[`border_color${suffix}`],
-  ring_color: params[`ring_color${suffix}`],
-  prog_bar_bg_color: params[`prog_bar_bg_color${suffix}`],
-  theme: params[`theme${suffix}`],
-});
+): ColorInput =>
+  Object.fromEntries(
+    BASE_COLOR_KEYS.map((key) => [key, params[`${key}${suffix}`]]),
+  );
 
 /**
  * Returns resolved colors for both light and dark mode given all input params.
@@ -293,30 +299,10 @@ const getLightDarkColors = (
 type ColorParams = ColorInput & LightDarkColorParams;
 
 const COLOR_PARAM_KEYS: ReadonlyArray<keyof ColorParams> = [
-  "title_color",
-  "icon_color",
-  "text_color",
-  "bg_color",
-  "border_color",
-  "ring_color",
-  "prog_bar_bg_color",
-  "theme",
-  "title_color_light",
-  "icon_color_light",
-  "text_color_light",
-  "bg_color_light",
-  "border_color_light",
-  "ring_color_light",
-  "prog_bar_bg_color_light",
-  "theme_light",
-  "title_color_dark",
-  "icon_color_dark",
-  "text_color_dark",
-  "bg_color_dark",
-  "border_color_dark",
-  "ring_color_dark",
-  "prog_bar_bg_color_dark",
-  "theme_dark",
+  ...BASE_COLOR_KEYS,
+  ...THEME_VARIANTS.flatMap((variant) =>
+    BASE_COLOR_KEYS.map((key) => `${key}_${variant}` as const),
+  ),
 ];
 
 /**
@@ -332,12 +318,43 @@ const pickColorParams = (
     COLOR_PARAM_KEYS.filter((k) => k in query).map((k) => [k, query[k]]),
   );
 
+/** Params naming a theme rather than holding a color value. */
+const THEME_PARAM_KEYS: ReadonlyArray<keyof ColorParams> = [
+  "theme",
+  ...THEME_VARIANTS.map((variant) => `theme_${variant}` as const),
+];
+
+/**
+ * Finds the first color param holding an invalid color.
+ *
+ * Theme params are skipped: they name a theme, and an unknown name falls back
+ * to the default rather than being an error.
+ *
+ * @param params Color params, as returned by {@link pickColorParams}.
+ * @returns The first invalid param name, or null if all are valid.
+ */
+const findInvalidColorParam = (params: ColorParams): string | null =>
+  findInvalidColor(
+    Object.fromEntries(
+      Object.entries(params).filter(
+        ([key]) => !THEME_PARAM_KEYS.includes(key as keyof ColorParams),
+      ),
+    ),
+  );
+
 export {
   getCardColors,
   getLightDarkColors,
   findInvalidColor,
+  findInvalidColorParam,
   pickColorParams,
   isValidGradient,
   isBareHexColor,
   isPrefixedHexColor,
+
+  // Not re-exported from the package index: internal,
+  // exposed so tests can pin the accepted param list.
+  BASE_COLOR_KEYS,
+  THEME_VARIANTS,
+  COLOR_PARAM_KEYS,
 };

--- a/packages/core/tests/color.test.ts
+++ b/packages/core/tests/color.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BASE_COLOR_KEYS,
+  COLOR_PARAM_KEYS,
+  THEME_VARIANTS,
   findInvalidColor,
+  findInvalidColorParam,
   getCardColors,
   getLightDarkColors,
   isBareHexColor,
   isPrefixedHexColor,
   isValidGradient,
+  pickColorParams,
 } from "../src/common/color.js";
 
 describe("getCardColors", () => {
@@ -318,5 +323,71 @@ describe("findInvalidColor", () => {
         bg_color: "fff",
       }),
     ).toBe("title_color");
+  });
+});
+
+describe("color param surface", () => {
+  // These names are part of the public URL API: once released they cannot be
+  // renamed without breaking existing cards. Pinned deliberately, so adding or
+  // removing one has to be an explicit decision rather than a side effect.
+  it("accepts exactly these params", () => {
+    expect(COLOR_PARAM_KEYS).toStrictEqual([
+      "title_color",
+      "icon_color",
+      "text_color",
+      "bg_color",
+      "border_color",
+      "ring_color",
+      "prog_bar_bg_color",
+      "theme",
+      "title_color_light",
+      "icon_color_light",
+      "text_color_light",
+      "bg_color_light",
+      "border_color_light",
+      "ring_color_light",
+      "prog_bar_bg_color_light",
+      "theme_light",
+      "title_color_dark",
+      "icon_color_dark",
+      "text_color_dark",
+      "bg_color_dark",
+      "border_color_dark",
+      "ring_color_dark",
+      "prog_bar_bg_color_dark",
+      "theme_dark",
+    ]);
+  });
+
+  it("derives a light and dark variant for every base param", () => {
+    for (const key of BASE_COLOR_KEYS) {
+      for (const variant of THEME_VARIANTS) {
+        expect(COLOR_PARAM_KEYS).toContain(`${key}_${variant}`);
+      }
+    }
+    expect(COLOR_PARAM_KEYS).toHaveLength(
+      BASE_COLOR_KEYS.length * (THEME_VARIANTS.length + 1),
+    );
+  });
+
+  it("picks every accepted param off a query, and nothing else", () => {
+    const query = Object.fromEntries(
+      COLOR_PARAM_KEYS.map((key) => [key, "fff"]),
+    );
+    expect(
+      Object.keys(pickColorParams({ ...query, username: "x" })),
+    ).toStrictEqual([...COLOR_PARAM_KEYS]);
+  });
+
+  it("validates colors but skips theme params", () => {
+    expect(
+      findInvalidColorParam({ theme: "not-a-color", bg_color: "fff" }),
+    ).toBeNull();
+    expect(
+      findInvalidColorParam({ theme_dark: "not-a-color", bg_color: "fff" }),
+    ).toBeNull();
+    expect(findInvalidColorParam({ bg_color_dark: "not-a-color" })).toBe(
+      "bg_color_dark",
+    );
   });
 });


### PR DESCRIPTION
- Related to https://github.com/stats-organization/github-stats-extended/pull/430#pullrequestreview-4839897884

Derive the color param names from one source of truth.

They were spelled out in different places: 
1. the `ColorInput` interface
2. the `extractLightDarkColors` mapping, 
3. 24-entry `COLOR_PARAM_KEYS` array, 
4. theme-exclusion literal repeated in all five `api/*.js` files. 

Adding a param meant touching all four, with nothing to catch a miss.

Now everything derives from:

```ts
const BASE_COLOR_KEYS = [/* ... */ ] as const;

const THEME_VARIANTS = ["light", "dark"] as const;
```

`ColorInput` and `LightDarkColorParams` become mapped types over those keys,  `extractLightDarkColors` maps over `BASE_COLOR_KEYS`,  and `COLOR_PARAM_KEYS` is built by flat-mapping the variants.

The api files each repeated the same "theme params aren't colors" exclusion:

```js
findInvalidColor({ ...colorParams, theme: undefined, theme_light: undefined, theme_dark: undefined })
```

That's now `findInvalidColorParam(colorParams)`, with the exclusion derived in `color.ts`.