### PR TITLE
fix update-langs, align naming

### DIFF
--- a/.github/workflows/generate-language-colors.yml
+++ b/.github/workflows/generate-language-colors.yml
@@ -14,18 +14,8 @@ on:
     - cron: "0 0 */30 * *"
 
 permissions:
-  actions: read
-  checks: read
   contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
   pull-requests: write
-  repository-projects: read
-  security-events: read
-  statuses: read
 
 jobs:
   update-languages:
@@ -33,7 +23,7 @@ jobs:
       github.repository == 'anuraghazra/github-readme-stats' ||
       github.repository == 'stats-organization/github-readme-stats' ||
       github.repository == 'stats-organization/github-stats-extended'
-    name: Update supported languages
+    name: Generate Language Colors
     runs-on: ubuntu-latest
 
     steps:
@@ -44,17 +34,17 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Run update-languages-json.js script
-        run: pnpm --filter ./packages/core/ run generate-langs-json
+        run: pnpm --filter ./packages/core/ run generate-language-colors
 
       - name: Create Pull Request if upstream language file is changed
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit-message: "feat(backend): update languages JSON"
+          commit-message: "feat(core): update language colors"
           branch: "update_langs/patch"
           delete-branch: true
-          title: Update languages JSON
-          body: "The
-            [update-langs](https://github.com/stats-organization/github-stats-extended/actions/workflows/update-langs.yml)
-            action found new/updated languages in the [upstream languages JSON
-            file](https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml)."
+          title: Update languages colors
+          body: >-
+            The [generate-language-colors](https://github.com/stats-organization/github-stats-extended/actions/workflows/generate-language-colors.yml)
+            workflow detected changes in the [upstream languages JSON
+            file](https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml) and regenerated the local language colors JSON file.
           labels: "ci"

--- a/.github/workflows/generate-language-colors.yml
+++ b/.github/workflows/generate-language-colors.yml
@@ -19,10 +19,7 @@ permissions:
 
 jobs:
   update-languages:
-    if: |
-      github.repository == 'anuraghazra/github-readme-stats' ||
-      github.repository == 'stats-organization/github-readme-stats' ||
-      github.repository == 'stats-organization/github-stats-extended'
+    if: github.repository == 'stats-organization/github-stats-extended'
     name: Generate Language Colors
     runs-on: ubuntu-latest
 

--- a/.github/workflows/generate-language-colors.yml
+++ b/.github/workflows/generate-language-colors.yml
@@ -11,7 +11,7 @@ on:
     #        │ │  │   │ │
     #        │ │  │   │ │
     #        * *  *   * *
-    - cron: "0 0 */30 * *"
+    - cron: "45 22 */7 * *"
 
 permissions:
   contents: write

--- a/.github/workflows/generate-theme-readme.yml
+++ b/.github/workflows/generate-theme-readme.yml
@@ -6,6 +6,17 @@ on:
     paths:
       - "packages/core/src/themes/index.ts"
   workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │ ┌───────────── hour (0 - 23)
+    #        │ │  ┌───────────── day of the month (1 - 31)
+    #        │ │  │   ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │ │  │   │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │ │  │   │ │
+    #        │ │  │   │ │
+    #        │ │  │   │ │
+    #        * *  *   * *
+    - cron: "45 22 */7 * *"
 
 permissions: {}
 

--- a/.github/workflows/repeat-recent-requests.yml
+++ b/.github/workflows/repeat-recent-requests.yml
@@ -17,10 +17,7 @@ permissions: {}
 
 jobs:
   repeat-recent-requests:
-    if: |
-      github.repository == 'anuraghazra/github-readme-stats' ||
-      github.repository == 'stats-organization/github-readme-stats' ||
-      github.repository == 'stats-organization/github-stats-extended'
+    if: github.repository == 'stats-organization/github-stats-extended'
     name: Trigger server to update cached data.
     runs-on: ubuntu-latest
     steps:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     "lint": "eslint",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "generate-theme-readme": "node scripts/generate-theme-readme",
-    "generate-langs-json": "node scripts/generate-langs-json"
+    "generate-language-colors": "node scripts/generate-language-colors"
   },
   "devDependencies": {
     "@testing-library/dom": "10.4.1",

--- a/packages/core/scripts/generate-language-colors.js
+++ b/packages/core/scripts/generate-language-colors.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 
 import axios from "axios";
-import { default as jsYaml } from "js-yaml";
+import * as jsYaml from "js-yaml";
 import * as prettier from "prettier";
 
 const LANGS_FILEPATH = "./src/common/languageColors.json";


### PR DESCRIPTION
Like #433 for the update-langs workflow.
* rename the workflow, script, and pnpm command for consistency
* fix workflow which [broke](https://github.com/stats-organization/github-stats-extended/actions/workflows/update-langs.yml) after upgrading js-yaml a month ago
* reduced workflow permissions