### PR TITLE
feat(core): convert repo card to TypeScript

### DIFF
--- a/packages/core/src/cards/gist.ts
+++ b/packages/core/src/cards/gist.ts
@@ -16,7 +16,7 @@ import {
 } from "../common/render.js";
 import type { GistData } from "../fetchers/types.js";
 
-import type { GistCardOptions } from "./types.js";
+import type { CommonOptions } from "./types.js";
 
 const ICON_SIZE = 16;
 const CARD_DEFAULT_WIDTH = 400;
@@ -26,6 +26,11 @@ const DESCRIPTION_BOX_WIDTH = CARD_DEFAULT_WIDTH - 2 * X_OFFSET;
 const DESCRIPTION_FONT_SIZE = 13;
 const DESCRIPTION_LINE_HEIGHT_PX = 16;
 const DESCRIPTION_MAX_LINES = 10;
+
+interface GistCardOptions extends CommonOptions {
+  show_owner: boolean;
+  browser_rendering: boolean;
+}
 
 /**
  * Render gist card.

--- a/packages/core/src/cards/repo.ts
+++ b/packages/core/src/cards/repo.ts
@@ -14,9 +14,11 @@ import {
   wrappedTextNode,
   wrappedTextStyles,
 } from "../common/render.js";
+import type { RepositoryData } from "../fetchers/types.js";
 import { repoCardLocales } from "../translations.js";
 
 import { createTextNode } from "./stats.js";
+import type { CommonOptions } from "./types.js";
 
 const ICON_SIZE = 16;
 const CARD_DEFAULT_WIDTH = 400;
@@ -25,13 +27,36 @@ const DESCRIPTION_FONT_SIZE = 13;
 const DESCRIPTION_LINE_HEIGHT_PX = 16;
 const DESCRIPTION_MAX_LINES = 3;
 
+interface RepoCardOptions extends CommonOptions {
+  show_owner: boolean;
+  browser_rendering: boolean;
+  description_lines_count: number;
+  card_width_input: number;
+  show: Array<string>;
+  show_icons: boolean;
+  number_format: string;
+  text_bold: boolean;
+  line_height: number | string;
+  username: string;
+}
+
+interface RepoStatItem {
+  icon: string;
+  label: string;
+  value: number | undefined;
+  id: string;
+  link: string;
+  unitSymbol?: string;
+}
+
 /**
  * Retrieves the repository description and wraps it to fit the card width.
  *
- * @param {string} label The repository description.
- * @returns {string} Wrapped repo description SVG object.
+ * @param label The repository description.
+ * @param xOffset Horizontal offset of the badge.
+ * @returns Wrapped repo description SVG object.
  */
-const getBadgeSVG = (label, xOffset = 0) => {
+const getBadgeSVG = (label: string, xOffset = 0): string => {
   if (!Number.isFinite(xOffset)) {
     throw new Error(`Invalid xOffset: "${xOffset}"`);
   }
@@ -52,18 +77,16 @@ const getBadgeSVG = (label, xOffset = 0) => {
 };
 
 /**
- * @typedef {import("../fetchers/types").RepositoryData} RepositoryData Repository data.
- * @typedef {import("./types").RepoCardOptions} RepoCardOptions Repo card options.
- */
-
-/**
  * Renders repository card details.
  *
- * @param {RepositoryData} repo Repository data.
- * @param {Partial<RepoCardOptions>} options Card options.
- * @returns {string} Repository card SVG object.
+ * @param repo Repository data.
+ * @param options Card options.
+ * @returns Repository card SVG object.
  */
-const renderRepoCard = (repo, options = {}) => {
+const renderRepoCard = (
+  repo: RepositoryData,
+  options: Partial<RepoCardOptions> = {},
+): string => {
   const {
     name,
     nameWithOwner,
@@ -108,11 +131,11 @@ const renderRepoCard = (repo, options = {}) => {
     translations: repoCardLocales,
   });
 
-  let repoFilter = encodeURIComponent(buildSearchFilter([nameWithOwner], []));
-  const encodedUsername = encodeURIComponent(username);
-  const STATS = {};
+  const repoFilter = encodeURIComponent(buildSearchFilter([nameWithOwner], []));
+  const encodedUsername = encodeURIComponent(username ?? "");
+  const STATS: Record<string, RepoStatItem> = {};
   if (show.includes("prs_authored")) {
-    STATS.prs_authored = {
+    STATS["prs_authored"] = {
       icon: icons.prs,
       label: i18n.t("repocard.prs-authored"),
       value: totalPRsAuthored,
@@ -121,7 +144,7 @@ const renderRepoCard = (repo, options = {}) => {
     };
   }
   if (show.includes("prs_commented")) {
-    STATS.prs_commented = {
+    STATS["prs_commented"] = {
       icon: icons.comments,
       label: i18n.t("repocard.prs-commented"),
       value: totalPRsCommented,
@@ -130,7 +153,7 @@ const renderRepoCard = (repo, options = {}) => {
     };
   }
   if (show.includes("prs_reviewed")) {
-    STATS.prs_reviewed = {
+    STATS["prs_reviewed"] = {
       icon: icons.reviews,
       label: i18n.t("repocard.prs-reviewed"),
       value: totalPRsReviewed,
@@ -139,7 +162,7 @@ const renderRepoCard = (repo, options = {}) => {
     };
   }
   if (show.includes("issues_authored")) {
-    STATS.issues_authored = {
+    STATS["issues_authored"] = {
       icon: icons.issues,
       label: i18n.t("repocard.issues-authored"),
       value: totalIssuesAuthored,
@@ -148,7 +171,7 @@ const renderRepoCard = (repo, options = {}) => {
     };
   }
   if (show.includes("issues_commented")) {
-    STATS.issues_commented = {
+    STATS["issues_commented"] = {
       icon: icons.discussions_started,
       label: i18n.t("repocard.issues-commented"),
       value: totalIssuesCommented,
@@ -157,20 +180,20 @@ const renderRepoCard = (repo, options = {}) => {
     };
   }
 
-  const statItems = Object.keys(STATS).map((key, index) =>
+  const statItems = Object.values(STATS).map((stat, index) =>
     // create the text nodes, and pass index so that we can calculate the line spacing
     createTextNode({
-      icon: STATS[key].icon,
-      label: STATS[key].label,
-      value: STATS[key].value,
-      id: STATS[key].id,
-      unitSymbol: STATS[key].unitSymbol,
+      icon: stat.icon,
+      label: stat.label,
+      value: stat.value ?? 0,
+      id: stat.id,
+      unitSymbol: stat.unitSymbol,
       index,
       showIcons: show_icons,
       shiftValuePos: 14.01,
       bold: text_bold,
       numberFormat: number_format,
-      link: STATS[key].link,
+      link: stat.link,
       labelXOffset: 23,
     }),
   );
@@ -183,7 +206,8 @@ const renderRepoCard = (repo, options = {}) => {
   const desc = parseEmojis(description || "No description provided");
   const descriptionBoxWidth = card_width - 2 * X_OFFSET;
 
-  let descriptionLinesCount, descriptionSvg;
+  let descriptionLinesCount: number;
+  let descriptionSvg: string;
   if (browser_rendering) {
     // The browser performs the actual text wrapping inside the foreignObject;
     // we only estimate the line count server-side so the SVG can reserve enough
@@ -270,7 +294,7 @@ const renderRepoCard = (repo, options = {}) => {
     gap: 25,
   }).join("");
 
-  let extraRows = [];
+  const extraRows: Array<string> = [];
   for (let i = 0; i < statItems.length; i += 2) {
     extraRows.push(
       flexLayout({
@@ -343,14 +367,12 @@ const renderRepoCard = (repo, options = {}) => {
   return card.render(`
     ${
       isTemplate
-        ? // @ts-ignore
-          getBadgeSVG(
+        ? getBadgeSVG(
             i18n.t("repocard.template"),
             card_width - CARD_DEFAULT_WIDTH,
           )
         : isArchived
-          ? // @ts-ignore
-            getBadgeSVG(
+          ? getBadgeSVG(
               i18n.t("repocard.archived"),
               card_width - CARD_DEFAULT_WIDTH,
             )

--- a/packages/core/src/cards/types.ts
+++ b/packages/core/src/cards/types.ts
@@ -3,7 +3,7 @@ import type { themes } from "../themes/index.js";
 type ThemeNames = keyof typeof themes;
 type RankIcon = "default" | "github" | "percentile";
 
-interface CommonOptions {
+export interface CommonOptions {
   title_color: string;
   icon_color: string;
   text_color: string;
@@ -15,7 +15,7 @@ interface CommonOptions {
   hide_border: boolean;
 }
 
-export type StatCardOptions = CommonOptions & {
+export interface StatCardOptions extends CommonOptions {
   hide: Array<string>;
   show_icons: boolean;
   hide_title: boolean;
@@ -32,22 +32,9 @@ export type StatCardOptions = CommonOptions & {
   text_bold: boolean;
   rank_icon: RankIcon;
   show: Array<string>;
-};
+}
 
-export type RepoCardOptions = CommonOptions & {
-  show_owner: boolean;
-  browser_rendering: boolean;
-  description_lines_count: number;
-  card_width_input: number;
-  show: Array<string>;
-  show_icons: boolean;
-  number_format: string;
-  text_bold: boolean;
-  line_height: number | string;
-  username: string;
-};
-
-export type TopLangOptions = CommonOptions & {
+export interface TopLangOptions extends CommonOptions {
   hide_title: boolean;
   card_width: number;
   hide: Array<string>;
@@ -59,9 +46,9 @@ export type TopLangOptions = CommonOptions & {
   hide_values: boolean;
   prog_bar_bg_color: string;
   stats_format: "percentages" | "bytes";
-};
+}
 
-export type WakaTimeOptions = CommonOptions & {
+export interface WakaTimeOptions extends CommonOptions {
   hide_title: boolean;
   hide: Array<string>;
   card_width: number;
@@ -72,9 +59,4 @@ export type WakaTimeOptions = CommonOptions & {
   langs_count: number;
   display_format: "time" | "percent";
   disable_animations: boolean;
-};
-
-export type GistCardOptions = CommonOptions & {
-  show_owner: boolean;
-  browser_rendering: boolean;
-};
+}

--- a/packages/core/src/common/I18n.ts
+++ b/packages/core/src/common/I18n.ts
@@ -16,7 +16,8 @@ class I18n<Translations extends Record<string, Record<string, string>>> {
     locale,
     translations,
   }: {
-    locale?: string;
+    // `| undefined`: card callers forward possibly-undefined query options
+    locale?: string | undefined;
     translations: Translations;
   }) {
     this.locale = locale || FALLBACK_LOCALE;

--- a/packages/core/src/fetchers/types.ts
+++ b/packages/core/src/fetchers/types.ts
@@ -14,12 +14,12 @@ export interface RepoInfo {
   isArchived: boolean;
   isTemplate: boolean;
   stargazerCount: number;
-  description: string;
+  description: string | null;
   primaryLanguage: {
-    color: string;
-    id: string;
-    name: string;
-  };
+    color: string | null;
+    id?: string;
+    name: string | null;
+  } | null;
   forkCount: number;
 }
 

--- a/packages/core/tests/renderRepoCard.test.ts
+++ b/packages/core/tests/renderRepoCard.test.ts
@@ -4,9 +4,10 @@ import { describe, expect, it } from "vitest";
 
 import pinApi from "../src/api/pin.js";
 import { renderRepoCard } from "../src/cards/repo.js";
+import type { RepositoryData } from "../src/fetchers/types.js";
 import { themes } from "../src/themes/index.js";
 
-const data_repo = {
+const data_repo: { repository: RepositoryData } = {
   repository: {
     nameWithOwner: "anuraghazra/convoychat",
     name: "convoychat",
@@ -16,6 +17,9 @@ const data_repo = {
       id: "MDg6TGFuZ3VhZ2UyODc=",
       name: "TypeScript",
     },
+    isPrivate: false,
+    isArchived: false,
+    isTemplate: false,
     stargazerCount: 38000,
     forkCount: 100,
   },
@@ -25,11 +29,11 @@ describe("Test renderRepoCard", () => {
   it("should render correctly", () => {
     document.body.innerHTML = renderRepoCard(data_repo.repository);
 
-    const [header] = document.getElementsByClassName("header");
+    const header = document.querySelector(".header");
 
     expect(header).toHaveTextContent("convoychat");
     expect(header).not.toHaveTextContent("anuraghazra");
-    expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
+    expect(document.querySelector(".description")).toHaveTextContent(
       // no space between "Chat" and "App" because there's a line break there
       "Help us take over the world! React + TS + GraphQL ChatApp",
     );
@@ -48,7 +52,7 @@ describe("Test renderRepoCard", () => {
     document.body.innerHTML = renderRepoCard(data_repo.repository, {
       show_owner: true,
     });
-    expect(document.getElementsByClassName("header")[0]).toHaveTextContent(
+    expect(document.querySelector(".header")).toHaveTextContent(
       "anuraghazra/convoychat",
     );
   });
@@ -59,7 +63,7 @@ describe("Test renderRepoCard", () => {
       name: "some-really-long-repo-name-for-test-purposes",
     });
 
-    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+    expect(document.querySelector(".header")?.textContent).toBe(
       "some-really-long-repo-name-for-test...",
     );
   });
@@ -71,13 +75,13 @@ describe("Test renderRepoCard", () => {
         "The quick brown fox jumps over the lazy dog is an English-language pangram—a sentence that contains all of the letters of the English alphabet",
     });
 
-    expect(
-      document.getElementsByClassName("description")[0].children[0].textContent,
-    ).toBe("The quick brown fox jumps over the lazy dog is an");
-
-    expect(
-      document.getElementsByClassName("description")[0].children[1].textContent,
-    ).toBe("English-language pangram—a sentence that contains all of");
+    const lines = document.querySelectorAll(".description tspan");
+    expect(lines[0]?.textContent).toBe(
+      "The quick brown fox jumps over the lazy dog is an",
+    );
+    expect(lines[1]?.textContent).toBe(
+      "English-language pangram—a sentence that contains all of",
+    );
 
     // Should not trim
     document.body.innerHTML = renderRepoCard({
@@ -85,7 +89,7 @@ describe("Test renderRepoCard", () => {
       description: "Small text should not trim",
     });
 
-    expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
+    expect(document.querySelector(".description")).toHaveTextContent(
       "Small text should not trim",
     );
   });
@@ -103,11 +107,11 @@ describe("Test renderRepoCard", () => {
     // Browser-side wrapping inside the foreignObject keeps the full text in
     // the DOM; the CSS line-clamp truncates whatever exceeds the line budget
     // at render time.
-    const description = document.getElementsByClassName("description")[0];
+    const description = document.querySelector<HTMLElement>(".description");
     expect(description).toHaveTextContent(
       "The quick brown fox jumps over the lazy dog is an English-language pangram—a sentence that contains all of the letters of the English alphabet",
     );
-    expect(description.style.getPropertyValue("--lines")).toBe("3");
+    expect(description?.style.getPropertyValue("--lines")).toBe("3");
 
     // Short descriptions should leave the full text visible without clamping.
     document.body.innerHTML = renderRepoCard({
@@ -115,7 +119,7 @@ describe("Test renderRepoCard", () => {
       description: "Small text should not trim",
     });
 
-    expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
+    expect(document.querySelector(".description")).toHaveTextContent(
       "Small text should not trim",
     );
   });
@@ -127,7 +131,7 @@ describe("Test renderRepoCard", () => {
     });
 
     // poop emoji may not show in all editors but it's there between "a" and "poo"
-    expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
+    expect(document.querySelector(".description")).toHaveTextContent(
       "This is a text with a 💩 poo emoji",
     );
   });
@@ -160,15 +164,16 @@ describe("Test renderRepoCard", () => {
     document.body.innerHTML = renderRepoCard(data_repo.repository);
 
     const styleTag = document.querySelector("style");
-    const stylesObject = cssToObject(styleTag.innerHTML);
+    const stylesObject = cssToObject(styleTag?.innerHTML ?? "");
 
-    const headerClassStyles = stylesObject[":host"][".header "];
-    const descClassStyles = stylesObject[":host"][".description "];
-    const iconClassStyles = stylesObject[":host"][".icon "];
+    const host = stylesObject[":host"];
+    const headerClassStyles = host?.[".header "];
+    const descClassStyles = host?.[".description "];
+    const iconClassStyles = host?.[".icon "];
 
-    expect(headerClassStyles.fill.trim()).toBe("#2f80ed");
-    expect(descClassStyles.fill.trim()).toBe("#434d58");
-    expect(iconClassStyles.fill.trim()).toBe("#586069");
+    expect(headerClassStyles?.["fill"]?.trim()).toBe("#2f80ed");
+    expect(descClassStyles?.["fill"]?.trim()).toBe("#434d58");
+    expect(iconClassStyles?.["fill"]?.trim()).toBe("#586069");
     expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
       "fill",
       "#fffefe",
@@ -188,15 +193,18 @@ describe("Test renderRepoCard", () => {
     });
 
     const styleTag = document.querySelector("style");
-    const stylesObject = cssToObject(styleTag.innerHTML);
+    const stylesObject = cssToObject(styleTag?.innerHTML ?? "");
 
-    const headerClassStyles = stylesObject[":host"][".header "];
-    const descClassStyles = stylesObject[":host"][".description "];
-    const iconClassStyles = stylesObject[":host"][".icon "];
+    const host = stylesObject[":host"];
+    const headerClassStyles = host?.[".header "];
+    const descClassStyles = host?.[".description "];
+    const iconClassStyles = host?.[".icon "];
 
-    expect(headerClassStyles.fill.trim()).toBe(`#${customColors.title_color}`);
-    expect(descClassStyles.fill.trim()).toBe(`#${customColors.text_color}`);
-    expect(iconClassStyles.fill.trim()).toBe(`#${customColors.icon_color}`);
+    const { title_color, text_color, icon_color } = customColors;
+
+    expect(headerClassStyles?.["fill"]?.trim()).toBe(`#${title_color}`);
+    expect(descClassStyles?.["fill"]?.trim()).toBe(`#${text_color}`);
+    expect(iconClassStyles?.["fill"]?.trim()).toBe(`#${icon_color}`);
     expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
       "fill",
       "#252525",
@@ -204,26 +212,28 @@ describe("Test renderRepoCard", () => {
   });
 
   it("should render with all the themes", () => {
-    Object.keys(themes).forEach((name) => {
+    Object.entries(themes).forEach(([name, themeData]) => {
       document.body.innerHTML = renderRepoCard(data_repo.repository, {
-        theme: name,
+        theme: name as keyof typeof themes,
       });
 
       const styleTag = document.querySelector("style");
-      const stylesObject = cssToObject(styleTag.innerHTML);
+      const stylesObject = cssToObject(styleTag?.innerHTML ?? "");
 
-      const headerClassStyles = stylesObject[":host"][".header "];
-      const descClassStyles = stylesObject[":host"][".description "];
-      const iconClassStyles = stylesObject[":host"][".icon "];
+      const host = stylesObject[":host"];
+      const headerClassStyles = host?.[".header "];
+      const descClassStyles = host?.[".description "];
+      const iconClassStyles = host?.[".icon "];
 
-      expect(headerClassStyles.fill.trim()).toBe(
-        `#${themes[name].title_color}`,
-      );
-      expect(descClassStyles.fill.trim()).toBe(`#${themes[name].text_color}`);
-      expect(iconClassStyles.fill.trim()).toBe(`#${themes[name].icon_color}`);
+      const { title_color, text_color, icon_color, bg_color } = themeData;
+
+      expect(headerClassStyles?.["fill"]?.trim()).toBe(`#${title_color}`);
+      expect(descClassStyles?.["fill"]?.trim()).toBe(`#${text_color}`);
+      expect(iconClassStyles?.["fill"]?.trim()).toBe(`#${icon_color}`);
+
       const backgroundElement = queryByTestId(document.body, "card-bg");
-      const backgroundElementFill = backgroundElement.getAttribute("fill");
-      expect([`#${themes[name].bg_color}`, "url(#gradient)"]).toContain(
+      const backgroundElementFill = backgroundElement?.getAttribute("fill");
+      expect([`#${bg_color}`, "url(#gradient)"]).toContain(
         backgroundElementFill,
       );
     });
@@ -236,15 +246,20 @@ describe("Test renderRepoCard", () => {
     });
 
     const styleTag = document.querySelector("style");
-    const stylesObject = cssToObject(styleTag.innerHTML);
+    const stylesObject = cssToObject(styleTag?.innerHTML ?? "");
 
-    const headerClassStyles = stylesObject[":host"][".header "];
-    const descClassStyles = stylesObject[":host"][".description "];
-    const iconClassStyles = stylesObject[":host"][".icon "];
+    const host = stylesObject[":host"];
+    const headerClassStyles = host?.[".header "];
+    const descClassStyles = host?.[".description "];
+    const iconClassStyles = host?.[".icon "];
 
-    expect(headerClassStyles.fill.trim()).toBe("#5a0");
-    expect(descClassStyles.fill.trim()).toBe(`#${themes.radical.text_color}`);
-    expect(iconClassStyles.fill.trim()).toBe(`#${themes.radical.icon_color}`);
+    expect(headerClassStyles?.["fill"]?.trim()).toBe("#5a0");
+    expect(descClassStyles?.["fill"]?.trim()).toBe(
+      `#${themes.radical.text_color}`,
+    );
+    expect(iconClassStyles?.["fill"]?.trim()).toBe(
+      `#${themes.radical.icon_color}`,
+    );
     expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
       "fill",
       `#${themes.radical.bg_color}`,
@@ -259,20 +274,24 @@ describe("Test renderRepoCard", () => {
     });
 
     const styleTag = document.querySelector("style");
-    const stylesObject = cssToObject(styleTag.innerHTML);
+    const stylesObject = cssToObject(styleTag?.innerHTML ?? "");
 
-    const headerClassStyles = stylesObject[":host"][".header "];
-    const descClassStyles = stylesObject[":host"][".description "];
-    const iconClassStyles = stylesObject[":host"][".icon "];
+    const host = stylesObject[":host"];
+    const headerClassStyles = host?.[".header "];
+    const descClassStyles = host?.[".description "];
+    const iconClassStyles = host?.[".icon "];
 
-    expect(headerClassStyles.fill.trim()).toBe(
-      `#${themes.default.title_color}`,
-    );
-    expect(descClassStyles.fill.trim()).toBe(`#${themes.default.text_color}`);
-    expect(iconClassStyles.fill.trim()).toBe(`#${themes.radical.icon_color}`);
+    // invalid overrides fall back to the default theme; the un-overridden
+    // icon/bg come from the requested `radical` theme
+    const { title_color, text_color } = themes.default;
+    const { icon_color, bg_color } = themes.radical;
+
+    expect(headerClassStyles?.["fill"]?.trim()).toBe(`#${title_color}`);
+    expect(descClassStyles?.["fill"]?.trim()).toBe(`#${text_color}`);
+    expect(iconClassStyles?.["fill"]?.trim()).toBe(`#${icon_color}`);
     expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
       "fill",
-      `#${themes.radical.bg_color}`,
+      `#${bg_color}`,
     );
   });
 
@@ -363,10 +382,10 @@ describe("Test renderRepoCard", () => {
   it("should fallback to default description", () => {
     document.body.innerHTML = renderRepoCard({
       ...data_repo.repository,
-      description: undefined,
+      description: null,
       isArchived: true,
     });
-    expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
+    expect(document.querySelector(".description")).toHaveTextContent(
       "No description provided",
     );
   });
@@ -404,11 +423,14 @@ describe("Test renderRepoCard", () => {
 
 describe("test pin API", () => {
   it("should return a permanent error for an invalid color parameter", async () => {
-    const result = await pinApi({
-      username: "user",
-      repo: "repo",
-      title_color: "not-a-color",
-    });
+    const result = await pinApi(
+      // api handler accepts a partial options object at runtime
+      {
+        username: "user",
+        repo: "repo",
+        title_color: "not-a-color",
+      } as Parameters<typeof pinApi>[0],
+    );
 
     expect(result.status).toBe("error - permanent");
     expect(result.content).toContain(


### PR DESCRIPTION
Another step of #140

- `src/cards/repo.js` + its test ➡️ `.ts`
- Colocated each card's options type into its own file; 
  `types.ts` keeps only the shared `CommonOptions` and the options of the js cards. 
  All `*CardOptions` are now `interface CardNameOptions extends CommonOptions` (were `type` intersections).
- `fetchers/types.ts`: made `RepoInfo.description` and `primaryLanguage` (and its fields) nullable to match the GraphQL schema. 
  The card already guards for these and the tests exercise them.
- `common/I18n.ts`: widened the constructor's `locale?: string` to accept `undefined`, since cards forward possibly-undefined query options.