### PR TITLE
downgrade pnpm to version 10

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,8 +65,8 @@ Selecting the right scopes for your token is important in case you want to displ
 
 #### Classic token
 
-- Go to [Account -> Settings -> Developer Settings -> Personal access tokens -> Tokens (classic)](https://github.com/settings/tokens).
-  - Click on `Generate new token -> Generate new token (classic)`.
+- Go to [Account → Settings → Developer Settings → Personal access tokens → Tokens (classic)](https://github.com/settings/tokens).
+  - Click on `Generate new token → Generate new token (classic)`.
   - Scopes to select:
     - repo
     - read:user
@@ -77,8 +77,8 @@ Selecting the right scopes for your token is important in case you want to displ
 > [!WARNING]\
 > This limits the scope of commits to public repositories only.
 
-- Go to [Account -> Settings -> Developer Settings -> Personal access tokens -> Fine-grained tokens](https://github.com/settings/personal-access-tokens).
-  - Click on `Generate new token -> Generate new token`.
+- Go to [Account → Settings → Developer Settings → Personal access tokens → Fine-grained tokens](https://github.com/settings/personal-access-tokens).
+  - Click on `Generate new token → Generate new token`.
   - Enter a token name
   - Select an expiration date
   - Select `All repositories`
@@ -120,11 +120,26 @@ Click on the deploy button to get started!
     3. Now you can make the variable `Sensitive` by checking the checkbox.
        ![](https://files.catbox.moe/mla5no.jpg)
 11. As `Root directory` select the `apps/backend` folder.
-12. Click deploy. See your domains to use the API.
-13. In your Vercel project's settings, go to Environments → Production and change the branch tracking from "master" to "release". ("master" contains unreleased, potentially unstable code, while "release" contains the latest stable release.) Then go to "Deployments" → "..." button → "Create Deployment", select "release" and click "Deploy to production".
-14. optional: add an SQL database; by using e.g. the ["Nile" integration](https://vercel.com/marketplace/nile) or by manually setting the environment variable `POSTGRES_URL`
-15. optional: [create your own OAuth App](https://github.com/settings/developers) and set environment variables `OAUTH_REDIRECT_URI`, `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` on Vercel accordingly
-16. optional: set the environment variable `TURBO_PLATFORM_ENV_DISABLED` to `true` to disable the build-time warning from [turbo](https://turborepo.dev/) about environment variables missing from "turbo.json" - This warning is not relevant in our project.
+12. Click deploy.
+13. Point your Vercel project at the `release` branch instead of `master`.  
+    `master` contains unreleased, potentially unstable code, while `release` contains the latest stable release.
+    1. In your Vercel project settings, go to `Environments → Production` and change the tracked branch from `master` to `release`.
+    2. Go to `Deployments → ... → Create Deployment`, select `release` and click `Deploy to production`.
+14. See your domains to use the API!
+
+### Optional steps
+
+#### Add an SQL database
+
+Add an SQL database, either through an integration such as ["Nile"](https://vercel.com/marketplace/nile), or by manually setting the environment variable `POSTGRES_URL`.
+
+#### Use your own OAuth App
+
+[Create your own OAuth App](https://github.com/settings/developers) and set the environment variables `OAUTH_REDIRECT_URI`, `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` on Vercel accordingly.
+
+#### Silence the turbo build warning
+
+Set the environment variable `TURBO_PLATFORM_ENV_DISABLED` to `true` to disable the build-time warning from [turbo](https://turborepo.dev/) about environment variables missing from `turbo.json`. This warning is not relevant in our project.
 
 ### Available environment variables
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,6 @@
 # Run It Yourself
 
-We cache generated cards for a few hours to avoid potential rate-limiting in the GitHub API or on Vercel. If you want to set your own cache duration or you want to include private contributions in your stats without granting our hosted version of GitHub-Stats-Extended access to your private contributions, you can run GitHub-Stats-Extended on your own.
+We cache generated cards for a few hours or days to avoid potential rate-limiting in the GitHub API or on Vercel. If you want to set your own cache duration or you want to include private contributions in your stats without granting our hosted version of GitHub-Stats-Extended access to your private contributions, you can run GitHub-Stats-Extended on your own.
 
 GitHub Actions is the simplest setup with static SVGs stored in your repo but less frequent updates, while self-hosting GitHub-Stats-Extended on Vercel takes more work and can serve fresher stats (with caching).
 
@@ -104,7 +104,7 @@ Click on the deploy button to get started!
 3. Sign in with GitHub by pressing `Continue with GitHub`.
    ![](https://files.catbox.moe/b9oxey.png)
 4. Sign in to GitHub and allow access to all repositories if prompted.
-5. Fork this repo.
+5. Fork this repo. Disable "Copy the `master` branch only".
 6. Go back to your [Vercel dashboard](https://vercel.com/dashboard).
 7. To import a project, click the `Add New...` button and select the `Project` option.
    ![](https://files.catbox.moe/3n76fh.png)
@@ -120,10 +120,11 @@ Click on the deploy button to get started!
     3. Now you can make the variable `Sensitive` by checking the checkbox.
        ![](https://files.catbox.moe/mla5no.jpg)
 11. As `Root directory` select the `apps/backend` folder.
-12. Click deploy, and you're good to go. See your domains to use the API!
-13. optional: add an SQL database; by using e.g. the ["Nile" integration](https://vercel.com/marketplace/nile) or by manually setting the environment variable `POSTGRES_URL`
-14. optional: [create your own OAuth App](https://github.com/settings/developers) and set environment variables `OAUTH_REDIRECT_URI`, `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` on Vercel accordingly
-15. optional: set the environment variable `TURBO_PLATFORM_ENV_DISABLED` to `true` to disable the build-time warning from [turbo](https://turborepo.dev/) about environment variables missing from "turbo.json" - This warning is not relevant in our project.
+12. Click deploy. See your domains to use the API.
+13. In your Vercel project's settings, go to Environments → Production and change the branch tracking from "master" to "release". ("master" contains unreleased, potentially unstable code, while "release" contains the latest stable release.) Then go to "Deployments" → "..." button → "Create Deployment", select "release" and click "Deploy to production".
+14. optional: add an SQL database; by using e.g. the ["Nile" integration](https://vercel.com/marketplace/nile) or by manually setting the environment variable `POSTGRES_URL`
+15. optional: [create your own OAuth App](https://github.com/settings/developers) and set environment variables `OAUTH_REDIRECT_URI`, `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET` on Vercel accordingly
+16. optional: set the environment variable `TURBO_PLATFORM_ENV_DISABLED` to `true` to disable the build-time warning from [turbo](https://turborepo.dev/) about environment variables missing from "turbo.json" - This warning is not relevant in our project.
 
 ### Available environment variables
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stats-organization/root",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
+  "packageManager": "pnpm@10.34.1+sha512.b58fbde6dca66a929538021581f648b4570b6ca19b18e7cbd7f2c07a7b24454155388dacdf08f2af3678e88a6d1fe04f9d609df24bf51735a060ea041b374ab7",
   "devDependencies": {
     "@eslint-react/eslint-plugin": "5.17.1",
     "@eslint/compat": "2.1.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,10 +2,10 @@ packages:
   - apps/*
   - packages/*
 
-allowBuilds:
-  "@swc/core": true
-  esbuild: true
-  unrs-resolver: true
+onlyBuiltDependencies:
+  - "@swc/core"
+  - esbuild
+  - unrs-resolver
 
 catalog:
   "@vitest/coverage-v8": 4.1.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# `packageManager` in package.json is deliberately held at pnpm 10.
+# Vercel does not support pnpm 11 yet, and deploying with it makes every request fail at runtime.
+# See https://github.com/stats-organization/github-stats-extended/pull/459
+#
+# Re-check Vercel's supported package managers before updating again:
+# https://vercel.com/docs/package-managers#supported-package-managers
 packages:
   - apps/*
   - packages/*


### PR DESCRIPTION
Upgrading pnpm to version 11 led to errors on Vercel on each request. https://github.com/stats-organization/github-stats-extended/issues/458 shows an example stack trace. Vercel doesn't support pnpm 11 yet according to [their docs](https://vercel.com/docs/package-managers). I have tried understanding and fixing the actual issue, but had to give up at some point. So for now let's downgrade to pnpm 10, wait for Vercel to support pnpm 11, then upgrade again.

Additionally, #458 showed that we should direct users to use the `release` branch when self-hosting. So this PR also updates the docs accordingly.

> [!NOTE]
When this PR is approved I should create an issue for the pnpm 11 upgrade.