### PR TITLE
fix: refinements and bugfixes for new themes

### DIFF
--- a/apps/frontend/src/pages/Home/Home.tsx
+++ b/apps/frontend/src/pages/Home/Home.tsx
@@ -252,6 +252,7 @@ export function HomeScreen({ stage, setStage }: HomeScreenProps): JSX.Element {
             <ThemeStage
               card={cardBuilder}
               theme={theme}
+              isRepoCard={isRepoCard}
               onThemeChange={(theme) => {
                 setTheme(theme);
                 setStage(4);

--- a/apps/frontend/src/pages/Home/stages/Theme.tsx
+++ b/apps/frontend/src/pages/Home/stages/Theme.tsx
@@ -1,3 +1,4 @@
+import type { ThemeName } from "@stats-organization/github-readme-stats-core";
 import { themes } from "@stats-organization/github-readme-stats-core";
 import type { JSX } from "react";
 
@@ -10,8 +11,6 @@ import type { CardUrlBuilder } from "../../../models/CardUrl";
 import { useTheme } from "../../../redux/selectors/themeSelectors";
 
 const excludedThemes = [
-  "default",
-  "default_repocard",
   "github_dark",
   "merko",
   "blue-green",
@@ -21,29 +20,51 @@ const excludedThemes = [
   "holi",
 ];
 
+const allThemeNames = Object.keys(themes) as Array<ThemeName>;
+
 // Light themes first, adaptive themes in the middle, dark themes last.
-const themeList = Object.keys(themes)
-  .filter((myTheme) => !excludedThemes.includes(myTheme))
-  .sort((a, b) => getThemeSortRank(a) - getThemeSortRank(b));
+const forPicker = (names: ReadonlyArray<ThemeName>) =>
+  names
+    .filter((name) => !excludedThemes.includes(name))
+    .sort((a, b) => getThemeSortRank(a) - getThemeSortRank(b));
+
+// Some themes come in pairs: `X_repocard` for the repo and gist cards, `X` for
+// the stats, top languages and WakaTime cards. Each side offers only its own
+// variant, so the theme Home.tsx starts on is always one of the entries here.
+//
+// Keep in sync with `generateTable` in `packages/core/scripts/generate-theme-readme.js`,
+// which splits the theme README tables by the same rule.
+const repoCardThemes = forPicker(
+  allThemeNames.filter(
+    (name) => !allThemeNames.includes(`${name}_repocard` as ThemeName),
+  ),
+);
+
+const nonRepoCardThemes = forPicker(
+  allThemeNames.filter((name) => !name.endsWith("_repocard")),
+);
 
 interface ThemeStageProps {
   card: CardUrlBuilder;
   theme: string;
+  isRepoCard: boolean;
   onThemeChange: (theme: string) => void;
 }
 
 export function ThemeStage({
   theme,
   card,
+  isRepoCard,
   onThemeChange,
 }: ThemeStageProps): JSX.Element {
   const { isDark } = useTheme();
+  const themeList = isRepoCard ? repoCardThemes : nonRepoCardThemes;
 
   return (
     <>
       <div className="flex flex-wrap">
         {themeList.map((myTheme) => {
-          const themeColors = themes[myTheme as keyof typeof themes];
+          const themeColors = themes[myTheme];
           return (
             <button
               className="p-2 lg:p-4"

--- a/docs/advanced_documentation.md
+++ b/docs/advanced_documentation.md
@@ -84,8 +84,8 @@ You can look at a preview for [all available themes](../packages/core/src/themes
 
 #### Light and Dark Mode
 
-[![Anurag's GitHub stats-Dark](https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&theme=dark_github#gh-dark-mode-only)](https://github.com/stats-organization/github-stats-extended#responsive-card-theme#gh-dark-mode-only)
-[![Anurag's GitHub stats-Light](https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&theme=light_github#gh-light-mode-only)](https://github.com/stats-organization/github-stats-extended#responsive-card-theme#gh-light-mode-only)
+[![Anurag's GitHub stats-Dark](https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&theme=dark_github#gh-dark-mode-only)](#light-and-dark-mode)
+[![Anurag's GitHub stats-Light](https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&theme=light_github#gh-light-mode-only)](#light-and-dark-mode)
 
 There are several methods you can use to create dynamic themes on the client side.
 

--- a/packages/core/scripts/generate-theme-readme.js
+++ b/packages/core/scripts/generate-theme-readme.js
@@ -64,11 +64,25 @@ const createTableItem = ({ link, label, isRepoCard }) => {
   return `\`${label}\` ![${link}][${link}${isRepoCard ? "_repo" : ""}]`;
 };
 
+const allThemeNames = Object.keys(themes);
+
+// Some themes come in pairs: `X_repocard` for the repo and gist cards, `X` for
+// the stats, top languages and WakaTime cards. Each table lists only its own
+// variant.
+//
+// Keep in sync with the theme lists in `apps/frontend/src/pages/Home/stages/Theme.tsx`,
+// which splits the picker by the same rule.
+const repoCardThemes = allThemeNames.filter(
+  (name) => !allThemeNames.includes(`${name}_repocard`),
+);
+
+const nonRepoCardThemes = allThemeNames.filter(
+  (name) => !name.endsWith("_repocard"),
+);
+
 const generateTable = ({ isRepoCard }) => {
   const rows = [];
-  const themesFiltered = Object.keys(themes).filter(
-    (name) => name !== (isRepoCard ? "default" : "default_repocard"),
-  );
+  const themesFiltered = isRepoCard ? repoCardThemes : nonRepoCardThemes;
 
   for (let i = 0; i < themesFiltered.length; i += 3) {
     const one = themesFiltered[i];

--- a/packages/core/src/cards/types.ts
+++ b/packages/core/src/cards/types.ts
@@ -1,6 +1,5 @@
-import type { themes } from "../themes/index.js";
+import type { ThemeName } from "../themes/index.js";
 
-type ThemeNames = keyof typeof themes;
 type RankIcon = "default" | "github" | "percentile";
 
 interface CommonOptions {
@@ -8,7 +7,7 @@ interface CommonOptions {
   icon_color: string;
   text_color: string;
   bg_color: string;
-  theme: ThemeNames;
+  theme: ThemeName;
   border_radius: number;
   border_color: string;
   locale: string;

--- a/packages/core/src/common/color.ts
+++ b/packages/core/src/common/color.ts
@@ -1,4 +1,5 @@
 import { themes } from "../themes/index.js";
+import type { ThemeName } from "../themes/index.js";
 
 /** Matches a 3-, 4-, 6-, or 8-digit hex color with no leading `#`. */
 const HEX_COLOR =
@@ -174,7 +175,7 @@ const getCardColors = ({
   const isThemeProvided = theme !== undefined && theme in themes;
 
   const selectedTheme = isThemeProvided
-    ? themes[theme as keyof typeof themes]
+    ? themes[theme as ThemeName]
     : defaultTheme;
 
   const defaultBorderColor =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,3 +23,4 @@ export { default as wakatime } from "./api/wakatime.js";
 export { getConfig, loadConfigFromEnv } from "./common/config.js";
 
 export { themes } from "./themes/index.js";
+export type { ThemeName } from "./themes/index.js";

--- a/packages/core/src/themes/README.md
+++ b/packages/core/src/themes/README.md
@@ -14,68 +14,74 @@ Use `?theme=THEME_NAME` parameter like so:
 
 > These themes work with all five of our cards: Stats Card, Repo Card, Gist Card, Top Languages Card, and WakaTime Card.
 
-|                                                                |                                                                |                                                                      |
-| :------------------------------------------------------------: | :------------------------------------------------------------: | :------------------------------------------------------------------: |
-|                 `default` ![default][default]                  |           `transparent` ![transparent][transparent]            |                `shadow_red` ![shadow_red][shadow_red]                |
-|          `shadow_green` ![shadow_green][shadow_green]          |           `shadow_blue` ![shadow_blue][shadow_blue]            |                         `dark` ![dark][dark]                         |
-|                 `radical` ![radical][radical]                  |                    `merko` ![merko][merko]                     |                    `gruvbox` ![gruvbox][gruvbox]                     |
-|        `gruvbox_light` ![gruvbox_light][gruvbox_light]         |             `tokyonight` ![tokyonight][tokyonight]             |                    `onedark` ![onedark][onedark]                     |
-|                   `cobalt` ![cobalt][cobalt]                   |              `synthwave` ![synthwave][synthwave]               |             `highcontrast` ![highcontrast][highcontrast]             |
-|                 `dracula` ![dracula][dracula]                  |                `prussian` ![prussian][prussian]                |                    `monokai` ![monokai][monokai]                     |
-|                       `vue` ![vue][vue]                        |                `vue-dark` ![vue-dark][vue-dark]                |       `shades-of-purple` ![shades-of-purple][shades-of-purple]       |
-|                `nightowl` ![nightowl][nightowl]                |                    `buefy` ![buefy][buefy]                     |                `blue-green` ![blue-green][blue-green]                |
-|                 `algolia` ![algolia][algolia]                  |          `great-gatsby` ![great-gatsby][great-gatsby]          |                    `darcula` ![darcula][darcula]                     |
-|                      `bear` ![bear][bear]                      |       `solarized-dark` ![solarized-dark][solarized-dark]       |        `solarized-light` ![solarized-light][solarized-light]         |
-|     `chartreuse-dark` ![chartreuse-dark][chartreuse-dark]      |                      `nord` ![nord][nord]                      |                      `gotham` ![gotham][gotham]                      |
-| `material-palenight` ![material-palenight][material-palenight] |              `graywhite` ![graywhite][graywhite]               | `vision-friendly-dark` ![vision-friendly-dark][vision-friendly-dark] |
-|             `ayu-mirage` ![ayu-mirage][ayu-mirage]             |     `midnight-purple` ![midnight-purple][midnight-purple]      |                         `calm` ![calm][calm]                         |
-|             `flag-india` ![flag-india][flag-india]             |                      `omni` ![omni][omni]                      |                       `react` ![react][react]                        |
-|                    `jolly` ![jolly][jolly]                     |             `maroongold` ![maroongold][maroongold]             |                       `yeblu` ![yeblu][yeblu]                        |
-|              `blueberry` ![blueberry][blueberry]               |           `slateorange` ![slateorange][slateorange]            |                   `kacho_ga` ![kacho_ga][kacho_ga]                   |
-|                   `outrun` ![outrun][outrun]                   |             `ocean_dark` ![ocean_dark][ocean_dark]             |              `city_lights` ![city_lights][city_lights]               |
-|           `github_dark` ![github_dark][github_dark]            | `github_dark_dimmed` ![github_dark_dimmed][github_dark_dimmed] |  `discord_old_blurple` ![discord_old_blurple][discord_old_blurple]   |
-|              `aura_dark` ![aura_dark][aura_dark]               |                    `panda` ![panda][panda]                     |          `noctis_minimus` ![noctis_minimus][noctis_minimus]          |
-|                 `cobalt2` ![cobalt2][cobalt2]                  |                    `swift` ![swift][swift]                     |                         `aura` ![aura][aura]                         |
-|             `apprentice` ![apprentice][apprentice]             |                 `moltack` ![moltack][moltack]                  |                `codeSTACKr` ![codeSTACKr][codeSTACKr]                |
-|              `rose_pine` ![rose_pine][rose_pine]               |    `catppuccin_latte` ![catppuccin_latte][catppuccin_latte]    |       `catppuccin_mocha` ![catppuccin_mocha][catppuccin_mocha]       |
-|             `date_night` ![date_night][date_night]             |          `one_dark_pro` ![one_dark_pro][one_dark_pro]          |                         `rose` ![rose][rose]                         |
-|                      `holi` ![holi][holi]                      |                      `neon` ![neon][neon]                      |                 `blue_navy` ![blue_navy][blue_navy]                  |
-|              `calm_pink` ![calm_pink][calm_pink]               |    `ambient_gradient` ![ambient_gradient][ambient_gradient]    |                                                                      |
+|                                                                |                                                                      |                                                                |
+| :------------------------------------------------------------: | :------------------------------------------------------------------: | :------------------------------------------------------------: |
+|                 `default` ![default][default]                  |             `light_github` ![light_github][light_github]             |           `dark_github` ![dark_github][dark_github]            |
+|           `transparent` ![transparent][transparent]            |                `shadow_red` ![shadow_red][shadow_red]                |          `shadow_green` ![shadow_green][shadow_green]          |
+|           `shadow_blue` ![shadow_blue][shadow_blue]            |                         `dark` ![dark][dark]                         |                 `radical` ![radical][radical]                  |
+|                    `merko` ![merko][merko]                     |                    `gruvbox` ![gruvbox][gruvbox]                     |        `gruvbox_light` ![gruvbox_light][gruvbox_light]         |
+|             `tokyonight` ![tokyonight][tokyonight]             |                    `onedark` ![onedark][onedark]                     |                   `cobalt` ![cobalt][cobalt]                   |
+|              `synthwave` ![synthwave][synthwave]               |             `highcontrast` ![highcontrast][highcontrast]             |                 `dracula` ![dracula][dracula]                  |
+|                `prussian` ![prussian][prussian]                |                    `monokai` ![monokai][monokai]                     |                       `vue` ![vue][vue]                        |
+|                `vue-dark` ![vue-dark][vue-dark]                |       `shades-of-purple` ![shades-of-purple][shades-of-purple]       |                `nightowl` ![nightowl][nightowl]                |
+|                    `buefy` ![buefy][buefy]                     |                `blue-green` ![blue-green][blue-green]                |                 `algolia` ![algolia][algolia]                  |
+|          `great-gatsby` ![great-gatsby][great-gatsby]          |                    `darcula` ![darcula][darcula]                     |                      `bear` ![bear][bear]                      |
+|       `solarized-dark` ![solarized-dark][solarized-dark]       |        `solarized-light` ![solarized-light][solarized-light]         |     `chartreuse-dark` ![chartreuse-dark][chartreuse-dark]      |
+|                      `nord` ![nord][nord]                      |                      `gotham` ![gotham][gotham]                      | `material-palenight` ![material-palenight][material-palenight] |
+|              `graywhite` ![graywhite][graywhite]               | `vision-friendly-dark` ![vision-friendly-dark][vision-friendly-dark] |             `ayu-mirage` ![ayu-mirage][ayu-mirage]             |
+|     `midnight-purple` ![midnight-purple][midnight-purple]      |                         `calm` ![calm][calm]                         |             `flag-india` ![flag-india][flag-india]             |
+|                      `omni` ![omni][omni]                      |                       `react` ![react][react]                        |                    `jolly` ![jolly][jolly]                     |
+|             `maroongold` ![maroongold][maroongold]             |                       `yeblu` ![yeblu][yeblu]                        |              `blueberry` ![blueberry][blueberry]               |
+|           `slateorange` ![slateorange][slateorange]            |                   `kacho_ga` ![kacho_ga][kacho_ga]                   |                   `outrun` ![outrun][outrun]                   |
+|             `ocean_dark` ![ocean_dark][ocean_dark]             |              `city_lights` ![city_lights][city_lights]               |           `github_dark` ![github_dark][github_dark]            |
+| `github_dark_dimmed` ![github_dark_dimmed][github_dark_dimmed] |  `discord_old_blurple` ![discord_old_blurple][discord_old_blurple]   |              `aura_dark` ![aura_dark][aura_dark]               |
+|                    `panda` ![panda][panda]                     |          `noctis_minimus` ![noctis_minimus][noctis_minimus]          |                 `cobalt2` ![cobalt2][cobalt2]                  |
+|                    `swift` ![swift][swift]                     |                         `aura` ![aura][aura]                         |             `apprentice` ![apprentice][apprentice]             |
+|                 `moltack` ![moltack][moltack]                  |                `codeSTACKr` ![codeSTACKr][codeSTACKr]                |              `rose_pine` ![rose_pine][rose_pine]               |
+|    `catppuccin_latte` ![catppuccin_latte][catppuccin_latte]    |       `catppuccin_mocha` ![catppuccin_mocha][catppuccin_mocha]       |             `date_night` ![date_night][date_night]             |
+|          `one_dark_pro` ![one_dark_pro][one_dark_pro]          |                         `rose` ![rose][rose]                         |                      `holi` ![holi][holi]                      |
+|                      `neon` ![neon][neon]                      |                 `blue_navy` ![blue_navy][blue_navy]                  |              `calm_pink` ![calm_pink][calm_pink]               |
+|    `ambient_gradient` ![ambient_gradient][ambient_gradient]    |                                                                      |                                                                |
 
 ## Repo Card
 
 > These themes work with all five of our cards: Stats Card, Repo Card, Gist Card, Top Languages Card, and WakaTime Card.
 
-|                                                                     |                                                                     |                                                                           |
-| :-----------------------------------------------------------------: | :-----------------------------------------------------------------: | :-----------------------------------------------------------------------: |
-|    `default_repocard` ![default_repocard][default_repocard_repo]    |           `transparent` ![transparent][transparent_repo]            |                `shadow_red` ![shadow_red][shadow_red_repo]                |
-|          `shadow_green` ![shadow_green][shadow_green_repo]          |           `shadow_blue` ![shadow_blue][shadow_blue_repo]            |                         `dark` ![dark][dark_repo]                         |
-|                 `radical` ![radical][radical_repo]                  |                    `merko` ![merko][merko_repo]                     |                    `gruvbox` ![gruvbox][gruvbox_repo]                     |
-|        `gruvbox_light` ![gruvbox_light][gruvbox_light_repo]         |             `tokyonight` ![tokyonight][tokyonight_repo]             |                    `onedark` ![onedark][onedark_repo]                     |
-|                   `cobalt` ![cobalt][cobalt_repo]                   |              `synthwave` ![synthwave][synthwave_repo]               |             `highcontrast` ![highcontrast][highcontrast_repo]             |
-|                 `dracula` ![dracula][dracula_repo]                  |                `prussian` ![prussian][prussian_repo]                |                    `monokai` ![monokai][monokai_repo]                     |
-|                       `vue` ![vue][vue_repo]                        |                `vue-dark` ![vue-dark][vue-dark_repo]                |       `shades-of-purple` ![shades-of-purple][shades-of-purple_repo]       |
-|                `nightowl` ![nightowl][nightowl_repo]                |                    `buefy` ![buefy][buefy_repo]                     |                `blue-green` ![blue-green][blue-green_repo]                |
-|                 `algolia` ![algolia][algolia_repo]                  |          `great-gatsby` ![great-gatsby][great-gatsby_repo]          |                    `darcula` ![darcula][darcula_repo]                     |
-|                      `bear` ![bear][bear_repo]                      |       `solarized-dark` ![solarized-dark][solarized-dark_repo]       |        `solarized-light` ![solarized-light][solarized-light_repo]         |
-|     `chartreuse-dark` ![chartreuse-dark][chartreuse-dark_repo]      |                      `nord` ![nord][nord_repo]                      |                      `gotham` ![gotham][gotham_repo]                      |
-| `material-palenight` ![material-palenight][material-palenight_repo] |              `graywhite` ![graywhite][graywhite_repo]               | `vision-friendly-dark` ![vision-friendly-dark][vision-friendly-dark_repo] |
-|             `ayu-mirage` ![ayu-mirage][ayu-mirage_repo]             |     `midnight-purple` ![midnight-purple][midnight-purple_repo]      |                         `calm` ![calm][calm_repo]                         |
-|             `flag-india` ![flag-india][flag-india_repo]             |                      `omni` ![omni][omni_repo]                      |                       `react` ![react][react_repo]                        |
-|                    `jolly` ![jolly][jolly_repo]                     |             `maroongold` ![maroongold][maroongold_repo]             |                       `yeblu` ![yeblu][yeblu_repo]                        |
-|              `blueberry` ![blueberry][blueberry_repo]               |           `slateorange` ![slateorange][slateorange_repo]            |                   `kacho_ga` ![kacho_ga][kacho_ga_repo]                   |
-|                   `outrun` ![outrun][outrun_repo]                   |             `ocean_dark` ![ocean_dark][ocean_dark_repo]             |              `city_lights` ![city_lights][city_lights_repo]               |
-|           `github_dark` ![github_dark][github_dark_repo]            | `github_dark_dimmed` ![github_dark_dimmed][github_dark_dimmed_repo] |  `discord_old_blurple` ![discord_old_blurple][discord_old_blurple_repo]   |
-|              `aura_dark` ![aura_dark][aura_dark_repo]               |                    `panda` ![panda][panda_repo]                     |          `noctis_minimus` ![noctis_minimus][noctis_minimus_repo]          |
-|                 `cobalt2` ![cobalt2][cobalt2_repo]                  |                    `swift` ![swift][swift_repo]                     |                         `aura` ![aura][aura_repo]                         |
-|             `apprentice` ![apprentice][apprentice_repo]             |                 `moltack` ![moltack][moltack_repo]                  |                `codeSTACKr` ![codeSTACKr][codeSTACKr_repo]                |
-|              `rose_pine` ![rose_pine][rose_pine_repo]               |    `catppuccin_latte` ![catppuccin_latte][catppuccin_latte_repo]    |       `catppuccin_mocha` ![catppuccin_mocha][catppuccin_mocha_repo]       |
-|             `date_night` ![date_night][date_night_repo]             |          `one_dark_pro` ![one_dark_pro][one_dark_pro_repo]          |                         `rose` ![rose][rose_repo]                         |
-|                      `holi` ![holi][holi_repo]                      |                      `neon` ![neon][neon_repo]                      |                 `blue_navy` ![blue_navy][blue_navy_repo]                  |
-|              `calm_pink` ![calm_pink][calm_pink_repo]               |    `ambient_gradient` ![ambient_gradient][ambient_gradient_repo]    |                                                                           |
+|                                                                     |                                                                              |                                                                           |
+| :-----------------------------------------------------------------: | :--------------------------------------------------------------------------: | :-----------------------------------------------------------------------: |
+|    `default_repocard` ![default_repocard][default_repocard_repo]    | `light_github_repocard` ![light_github_repocard][light_github_repocard_repo] | `dark_github_repocard` ![dark_github_repocard][dark_github_repocard_repo] |
+|           `transparent` ![transparent][transparent_repo]            |                 `shadow_red` ![shadow_red][shadow_red_repo]                  |             `shadow_green` ![shadow_green][shadow_green_repo]             |
+|           `shadow_blue` ![shadow_blue][shadow_blue_repo]            |                          `dark` ![dark][dark_repo]                           |                    `radical` ![radical][radical_repo]                     |
+|                    `merko` ![merko][merko_repo]                     |                      `gruvbox` ![gruvbox][gruvbox_repo]                      |           `gruvbox_light` ![gruvbox_light][gruvbox_light_repo]            |
+|             `tokyonight` ![tokyonight][tokyonight_repo]             |                      `onedark` ![onedark][onedark_repo]                      |                      `cobalt` ![cobalt][cobalt_repo]                      |
+|              `synthwave` ![synthwave][synthwave_repo]               |              `highcontrast` ![highcontrast][highcontrast_repo]               |                    `dracula` ![dracula][dracula_repo]                     |
+|                `prussian` ![prussian][prussian_repo]                |                      `monokai` ![monokai][monokai_repo]                      |                          `vue` ![vue][vue_repo]                           |
+|                `vue-dark` ![vue-dark][vue-dark_repo]                |        `shades-of-purple` ![shades-of-purple][shades-of-purple_repo]         |                   `nightowl` ![nightowl][nightowl_repo]                   |
+|                    `buefy` ![buefy][buefy_repo]                     |                 `blue-green` ![blue-green][blue-green_repo]                  |                    `algolia` ![algolia][algolia_repo]                     |
+|          `great-gatsby` ![great-gatsby][great-gatsby_repo]          |                      `darcula` ![darcula][darcula_repo]                      |                         `bear` ![bear][bear_repo]                         |
+|       `solarized-dark` ![solarized-dark][solarized-dark_repo]       |          `solarized-light` ![solarized-light][solarized-light_repo]          |        `chartreuse-dark` ![chartreuse-dark][chartreuse-dark_repo]         |
+|                      `nord` ![nord][nord_repo]                      |                       `gotham` ![gotham][gotham_repo]                        |    `material-palenight` ![material-palenight][material-palenight_repo]    |
+|              `graywhite` ![graywhite][graywhite_repo]               |  `vision-friendly-dark` ![vision-friendly-dark][vision-friendly-dark_repo]   |                `ayu-mirage` ![ayu-mirage][ayu-mirage_repo]                |
+|     `midnight-purple` ![midnight-purple][midnight-purple_repo]      |                          `calm` ![calm][calm_repo]                           |                `flag-india` ![flag-india][flag-india_repo]                |
+|                      `omni` ![omni][omni_repo]                      |                         `react` ![react][react_repo]                         |                       `jolly` ![jolly][jolly_repo]                        |
+|             `maroongold` ![maroongold][maroongold_repo]             |                         `yeblu` ![yeblu][yeblu_repo]                         |                 `blueberry` ![blueberry][blueberry_repo]                  |
+|           `slateorange` ![slateorange][slateorange_repo]            |                    `kacho_ga` ![kacho_ga][kacho_ga_repo]                     |                      `outrun` ![outrun][outrun_repo]                      |
+|             `ocean_dark` ![ocean_dark][ocean_dark_repo]             |                `city_lights` ![city_lights][city_lights_repo]                |              `github_dark` ![github_dark][github_dark_repo]               |
+| `github_dark_dimmed` ![github_dark_dimmed][github_dark_dimmed_repo] |    `discord_old_blurple` ![discord_old_blurple][discord_old_blurple_repo]    |                 `aura_dark` ![aura_dark][aura_dark_repo]                  |
+|                    `panda` ![panda][panda_repo]                     |           `noctis_minimus` ![noctis_minimus][noctis_minimus_repo]            |                    `cobalt2` ![cobalt2][cobalt2_repo]                     |
+|                    `swift` ![swift][swift_repo]                     |                          `aura` ![aura][aura_repo]                           |                `apprentice` ![apprentice][apprentice_repo]                |
+|                 `moltack` ![moltack][moltack_repo]                  |                 `codeSTACKr` ![codeSTACKr][codeSTACKr_repo]                  |                 `rose_pine` ![rose_pine][rose_pine_repo]                  |
+|    `catppuccin_latte` ![catppuccin_latte][catppuccin_latte_repo]    |        `catppuccin_mocha` ![catppuccin_mocha][catppuccin_mocha_repo]         |                `date_night` ![date_night][date_night_repo]                |
+|          `one_dark_pro` ![one_dark_pro][one_dark_pro_repo]          |                          `rose` ![rose][rose_repo]                           |                         `holi` ![holi][holi_repo]                         |
+|                      `neon` ![neon][neon_repo]                      |                   `blue_navy` ![blue_navy][blue_navy_repo]                   |                 `calm_pink` ![calm_pink][calm_pink_repo]                  |
+|    `ambient_gradient` ![ambient_gradient][ambient_gradient_repo]    |                                                                              |                                                                           |
 
 [default]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=default
 [default_repocard]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=default_repocard
+[light_github]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=light_github
+[dark_github]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=dark_github
+[light_github_repocard]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=light_github_repocard
+[dark_github_repocard]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=dark_github_repocard
 [transparent]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=transparent
 [shadow_red]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=shadow_red
 [shadow_green]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=shadow_green
@@ -151,6 +157,10 @@ Use `?theme=THEME_NAME` parameter like so:
 [ambient_gradient]: https://github-stats-extended.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=ambient_gradient
 [default_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=default
 [default_repocard_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=default_repocard
+[light_github_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=light_github
+[dark_github_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=dark_github
+[light_github_repocard_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=light_github_repocard
+[dark_github_repocard_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=dark_github_repocard
 [transparent_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=transparent
 [shadow_red_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=shadow_red
 [shadow_green_repo]: https://github-stats-extended.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=shadow_green

--- a/packages/core/src/themes/index.ts
+++ b/packages/core/src/themes/index.ts
@@ -28,24 +28,28 @@ export const themes = {
     icon_color: "0969da",
     text_color: "59636e",
     bg_color: "ffffff",
+    border_color: "d1d9e0",
   },
   dark_github: {
     title_color: "4493f8",
     icon_color: "4493f8",
     text_color: "9198a1",
     bg_color: "0d1117",
+    border_color: "3d444d",
   },
   light_github_repocard: {
     title_color: "0969da",
     icon_color: "59636e",
     text_color: "59636e",
     bg_color: "ffffff",
+    border_color: "d1d9e0",
   },
   dark_github_repocard: {
     title_color: "4493f8",
     icon_color: "9198a1",
     text_color: "9198a1",
     bg_color: "0d1117",
+    border_color: "3d444d",
   },
   transparent: {
     title_color: "006AFF",
@@ -498,3 +502,8 @@ export const themes = {
     bg_color: "35,4158d0,c850c0,ffcc70",
   },
 } as const satisfies Record<string, Theme>;
+
+/**
+ * Name of one of the {@link themes}.
+ */
+export type ThemeName = keyof typeof themes;


### PR DESCRIPTION
Found while reviewing #457.

1. Dark themes rendered a near-white border.
   `dark_github` / `dark_github_repocard` had no `border_color` and fell back to the default theme's `e4e2e2`. 
   Set GitHub's borders on all four new themes: `d1d9e0` light, `3d444d` dark.

2. Excluding `default` / `default_repocard` broke the theme picker.
  `Home.tsx` initializes to one of them and treats it as "emit no `theme=` param", so stage 3 opened with nothing selected and the theme-less URL became unreachable.

3. Paired themes were shown for the wrong card type.
   The picker now takes `isRepoCard` and lists only the matching variant, hiding duplicates while keeping each card type's `default` visible.

4. Theme README generator only knew the `default` pair, so the new themes would land in the wrong tables.

5. 3 and 4 share a rule, kept duplicated on purpose: which themes to advertise per card type is presentation, not rendering, so it stays out of core's API. 
   Both copies carry `Keep in sync` comments pointing at each other.

6. Dead docs anchor left by the `Responsive Card Theme` ➡️ `Light and Dark Mode` rename.

7. Core gains one export: the `ThemeName` type, replacing the private duplicate `ThemeNames` in `cards/types.ts` and the `keyof typeof themes` casts in `color.ts` and the picker.