### PR TITLE
top-langs: adapt test code to prod code

### DIFF
--- a/packages/core/src/cards/top-languages.ts
+++ b/packages/core/src/cards/top-languages.ts
@@ -200,13 +200,13 @@ const donutCenterTranslation = (totalLangs: number): number => {
  * @returns Trimmed top languages and total size.
  */
 const trimTopLanguages = (
-  topLangs: TopLangData | Array<Lang>,
-  langs_count?: number,
+  topLangs: TopLangData,
+  langs_count: number,
   hide?: Array<string>,
 ): { langs: Array<Lang>; totalLanguageSize: number } => {
   let langs = Object.values(topLangs);
   const langsToHide: Record<string, boolean> = {};
-  const langsCount = clampValue(langs_count ?? 1, 1, MAXIMUM_LANGS_COUNT);
+  const langsCount = clampValue(langs_count, 1, MAXIMUM_LANGS_COUNT);
 
   // populate langsToHide map for quick lookup while filtering out
   if (hide) {

--- a/packages/core/tests/renderTopLanguagesCard.test.ts
+++ b/packages/core/tests/renderTopLanguagesCard.test.ts
@@ -319,15 +319,19 @@ describe("Test renderTopLanguages helper functions", () => {
   });
 
   it("trimTopLanguages", () => {
-    expect(trimTopLanguages([])).toStrictEqual({
+    expect(trimTopLanguages({}, 5)).toStrictEqual({
       langs: [],
       totalLanguageSize: 0,
     });
-    expect(trimTopLanguages([langs.javascript])).toStrictEqual({
-      langs: [langs.javascript],
-      totalLanguageSize: 200,
-    });
-    expect(trimTopLanguages([langs.javascript, langs.HTML], 5)).toStrictEqual({
+    expect(trimTopLanguages({ javascript: langs.javascript }, 5)).toStrictEqual(
+      {
+        langs: [langs.javascript],
+        totalLanguageSize: 200,
+      },
+    );
+    expect(
+      trimTopLanguages({ javascript: langs.javascript, HTML: langs.HTML }, 5),
+    ).toStrictEqual({
       langs: [langs.javascript, langs.HTML],
       totalLanguageSize: 400,
     });


### PR DESCRIPTION
follow-up to https://github.com/stats-organization/github-stats-extended/pull/473

Instead of adapting our prod code's signatures for our test code, I think we should adapt our test code here.