### PR TITLE
fix(core): error handling and typed query for the per-year contributions fetch

### DIFF
--- a/packages/core/src/fetchers/stats.ts
+++ b/packages/core/src/fetchers/stats.ts
@@ -6,12 +6,12 @@ import { calculateRank } from "../calculateRank.js";
 import { getConfig } from "../common/config.js";
 import { CustomError, MissingParamError } from "../common/error.js";
 import { wrapTextMultiline } from "../common/fmt.js";
-import { request } from "../common/http.js";
 import { createGraphQLFetcher } from "../common/http.js";
 import type { GraphQLResponse } from "../common/http.js";
 import { logger } from "../common/log.js";
 import { buildSearchFilter, parseOwnerAffiliations } from "../common/ops.js";
 import { retryer } from "../common/retryer.js";
+import { buildContributionsDocument } from "../graphql/contributionsDocument.js";
 import {
   UserInfoDocument,
   UserReposDocument,
@@ -20,7 +20,6 @@ import type {
   RepoNodeFragment,
   UserInfoQuery,
   UserInfoQueryVariables,
-  YearContributionsFragment,
 } from "../graphql/generated/stats.js";
 
 import type { RepoUserStats, StatsData } from "./types.js";
@@ -276,10 +275,6 @@ const fetchRepoUserStats = async (
   return stats;
 };
 
-interface ContributionsQuery {
-  user: Record<string, YearContributionsFragment> | null;
-}
-
 /**
  * Fetch all-time contributions by building a single GraphQL query
  * for all the given years.
@@ -296,37 +291,32 @@ const fetchTotalContributions = async (
     return 0;
   }
 
-  const yearFields = years
-    .map(
-      (year) =>
-        // without the "to" field, 2024-01-01 would be included for year=2023
-        `year_${year}: contributionsCollection(from: "${year}-01-01T00:00:00Z", to: "${year}-12-31T23:59:59Z") { contributionCalendar { totalContributions } }`,
-    )
-    .join("\n");
-
-  const query = `
-    query userContributions($login: String!) {
-      user(login: $login) {
-        ${yearFields}
-      }
-    }
-  `;
-
-  const contributionsFetcher = (
-    variables: Record<string, unknown>,
-    token: string,
-  ): Promise<GraphQLResponse<ContributionsQuery>> => {
-    return request(
-      { query, variables },
-      { Authorization: `bearer ${token}` },
-    ) as Promise<GraphQLResponse<ContributionsQuery>>;
-  };
+  const contributionsFetcher = createGraphQLFetcher(
+    buildContributionsDocument(years),
+    "bearer",
+  );
 
   const contribRes = await retryer(
     contributionsFetcher,
     { login: username },
     pat,
   );
+
+  if (contribRes.data.errors) {
+    logger.error(contribRes.data.errors);
+    const firstError = contribRes.data.errors[0];
+    if (firstError?.message) {
+      throw new CustomError(
+        wrapTextMultiline(firstError.message, 525, 12)[0] ?? "",
+        contribRes.statusText,
+      );
+    }
+    throw new CustomError(
+      "Something went wrong while trying to retrieve the contributions data using the GraphQL API.",
+      CustomError.GRAPHQL_ERROR,
+    );
+  }
+
   const user = contribRes.data.data.user;
   if (!user) {
     return 0;

--- a/packages/core/src/graphql/contributionsDocument.ts
+++ b/packages/core/src/graphql/contributionsDocument.ts
@@ -1,0 +1,43 @@
+import type { YearContributionsFragment } from "./generated/stats.js";
+import { graphqlDocument } from "./graphqlDocument.js";
+
+interface ContributionsQueryVariables {
+  login: string;
+}
+
+interface ContributionsQuery {
+  user: Record<`year_${number}`, YearContributionsFragment> | null;
+}
+
+/**
+ * Build the all-time contributions query, one aliased `contributionsCollection` field per year.
+ * The shape is only known at runtime.
+ *
+ * @param years Contribution years, one `year_<year>` alias each.
+ * @returns Document for `createGraphQLFetcher`.
+ */
+const buildContributionsDocument = (years: Array<number>) => {
+  const yearFields = years
+    .map((year) => {
+      // without "to", 2024-01-01 would count toward year=2023
+      const from = `${year}-01-01T00:00:00Z`;
+      const to = `${year}-12-31T23:59:59Z`;
+      return `year_${year}: contributionsCollection(from: "${from}", to: "${to}") { ...YearContributions }`;
+    })
+    .join("\n");
+
+  // fragment must match queries/stats.graphql, which generates its type
+  return graphqlDocument<ContributionsQuery, ContributionsQueryVariables>(`
+query userContributions($login: String!) {
+  user(login: $login) {
+    ${yearFields}
+  }
+}
+fragment YearContributions on ContributionsCollection {
+  contributionCalendar {
+    totalContributions
+  }
+}`);
+};
+
+export { buildContributionsDocument };

--- a/packages/core/src/graphql/graphqlDocument.ts
+++ b/packages/core/src/graphql/graphqlDocument.ts
@@ -1,8 +1,7 @@
 /**
  * A GraphQL query paired with the types of its result and variables.
  *
- * `text` is what goes over the wire; the other two members only carry types and are
- * never assigned.
+ * `text` is what goes over the wire; the other two members only carry types and are never assigned.
  * Documents are generated from `queries/*.graphql`
  * See `scripts/generate-graphql-types.js`.
  */

--- a/packages/core/tests/fetchStats.test.ts
+++ b/packages/core/tests/fetchStats.test.ts
@@ -639,6 +639,82 @@ describe("Test fetchStats", () => {
     expect(stats.totalContributions).toBe(350);
   });
 
+  it("should throw when the contributions query returns an error", async () => {
+    mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+      const req = JSON.parse(cfg.data as string) as { query: string };
+      if (req.query.includes("contributionCalendar")) {
+        return [
+          200,
+          {
+            data: null,
+            errors: [{ message: "Some test GraphQL error" }],
+          },
+        ];
+      }
+      return [
+        200,
+        req.query.includes("totalCommitContributions") ? data_stats : data_repo,
+      ];
+    });
+
+    await expect(
+      fetchStats(
+        "anuraghazra",
+        false,
+        [],
+        false,
+        false,
+        false,
+        undefined,
+        [],
+        [],
+        false,
+        false,
+        false,
+        false,
+        false,
+        [],
+        true, // include_contributions
+      ),
+    ).rejects.toThrow("Some test GraphQL error");
+  });
+
+  it("should throw a generic error when the contributions query returns an error without a message", async () => {
+    mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+      const req = JSON.parse(cfg.data as string) as { query: string };
+      if (req.query.includes("contributionCalendar")) {
+        return [200, { data: null, errors: [{ type: "SOME_ERROR" }] }];
+      }
+      return [
+        200,
+        req.query.includes("totalCommitContributions") ? data_stats : data_repo,
+      ];
+    });
+
+    await expect(
+      fetchStats(
+        "anuraghazra",
+        false,
+        [],
+        false,
+        false,
+        false,
+        undefined,
+        [],
+        [],
+        false,
+        false,
+        false,
+        false,
+        false,
+        [],
+        true, // include_contributions
+      ),
+    ).rejects.toThrow(
+      "Something went wrong while trying to retrieve the contributions data using the GraphQL API.",
+    );
+  });
+
   it("should return correct data when user don't have any pull requests", async () => {
     mock
       .onPost("https://api.github.com/graphql")


### PR DESCRIPTION
- `fetchTotalContributions` read `contribRes.data.data.user` without checking for errors.
  Now follows the standard approach: first error message, wrapped for the card, or a generic  `GRAPHQL_ERROR`.
- The runtime-built contributions query is typed end to end: 
  the new `graphql/contributionsDocument.ts` assembles the per-year aliases around `...YearContributions` spreads (typed by the fragment in `stats.graphql`).
  It is sent via `createGraphQLFetcher`, the untyped `request` call and its cast are gone.