### PR TITLE
test(core): use jest-dom assertions for DOM checks

### DIFF
--- a/packages/core/tests/card.test.ts
+++ b/packages/core/tests/card.test.ts
@@ -75,27 +75,22 @@ describe("Card", () => {
     const card = new Card({ titlePrefixIcon: icons.contribs });
 
     document.body.innerHTML = card.render(``);
-    expect(document.getElementsByClassName("icon")[0]).toBeInTheDocument();
+    expect(document.querySelector(".icon")).toBeInTheDocument();
   });
 
   it("title should not have prefix icon", () => {
     const card = new Card({});
 
     document.body.innerHTML = card.render(``);
-    expect(document.getElementsByClassName("icon")[0]).toBeUndefined();
+    expect(document.querySelector(".icon")).not.toBeInTheDocument();
   });
 
   it("should have proper height, width", () => {
     const card = new Card({ height: 200, width: 200 });
     document.body.innerHTML = card.render(``);
-    expect(document.getElementsByTagName("svg")[0]).toHaveAttribute(
-      "height",
-      "200",
-    );
-    expect(document.getElementsByTagName("svg")[0]).toHaveAttribute(
-      "width",
-      "200",
-    );
+    const svg = document.querySelector("svg");
+    expect(svg).toHaveAttribute("height", "200");
+    expect(svg).toHaveAttribute("width", "200");
   });
 
   it("should have less height after title is hidden", () => {
@@ -103,10 +98,7 @@ describe("Card", () => {
     card.setHideTitle(true);
 
     document.body.innerHTML = card.render(``);
-    expect(document.getElementsByTagName("svg")[0]).toHaveAttribute(
-      "height",
-      "170",
-    );
+    expect(document.querySelector("svg")).toHaveAttribute("height", "170");
   });
 
   it("main-card-body should have proper when title is visible", () => {

--- a/packages/core/tests/renderGistCard.test.ts
+++ b/packages/core/tests/renderGistCard.test.ts
@@ -59,10 +59,10 @@ describe("test renderGistCard", () => {
         "The quick brown fox jumps over the lazy dog is an English-language pangram—a sentence that contains all of the letters of the English alphabet",
     });
     const lines = document.querySelectorAll(".description tspan");
-    expect(lines[0]?.textContent).toBe(
+    expect(lines[0]).toHaveTextContent(
       "The quick brown fox jumps over the lazy dog is an",
     );
-    expect(lines[1]?.textContent).toBe(
+    expect(lines[1]).toHaveTextContent(
       "English-language pangram—a sentence that contains all of",
     );
   });

--- a/packages/core/tests/renderRepoCard.test.ts
+++ b/packages/core/tests/renderRepoCard.test.ts
@@ -61,7 +61,7 @@ describe("Test renderRepoCard", () => {
       name: "some-really-long-repo-name-for-test-purposes",
     });
 
-    expect(document.querySelector(".header")?.textContent).toBe(
+    expect(document.querySelector(".header")).toHaveTextContent(
       "some-really-long-repo-name-for-test...",
     );
   });
@@ -74,10 +74,10 @@ describe("Test renderRepoCard", () => {
     });
 
     const lines = document.querySelectorAll(".description tspan");
-    expect(lines[0]?.textContent).toBe(
+    expect(lines[0]).toHaveTextContent(
       "The quick brown fox jumps over the lazy dog is an",
     );
-    expect(lines[1]?.textContent).toBe(
+    expect(lines[1]).toHaveTextContent(
       "English-language pangram—a sentence that contains all of",
     );
 
@@ -109,7 +109,7 @@ describe("Test renderRepoCard", () => {
     expect(description).toHaveTextContent(
       "The quick brown fox jumps over the lazy dog is an English-language pangram—a sentence that contains all of the letters of the English alphabet",
     );
-    expect(description?.style.getPropertyValue("--lines")).toBe("3");
+    expect(description).toHaveStyle({ "--lines": "3" });
 
     // Short descriptions should leave the full text visible without clamping.
     document.body.innerHTML = renderRepoCard({

--- a/packages/core/tests/renderStatsCard.test.ts
+++ b/packages/core/tests/renderStatsCard.test.ts
@@ -32,18 +32,16 @@ describe("Test renderStatsCard", () => {
   it("should render correctly", () => {
     document.body.innerHTML = renderStatsCard(stats);
 
-    expect(document.querySelector(".header")?.textContent).toBe(
+    expect(document.querySelector(".header")).toHaveTextContent(
       "Anurag Hazra's GitHub Stats",
     );
 
-    expect(document.body.querySelector("svg")?.getAttribute("height")).toBe(
-      "195",
-    );
-    expect(screen.getByTestId("stars").textContent).toBe("100");
-    expect(screen.getByTestId("commits").textContent).toBe("200");
-    expect(screen.getByTestId("issues").textContent).toBe("300");
-    expect(screen.getByTestId("prs").textContent).toBe("400");
-    expect(screen.getByTestId("contribs").textContent).toBe("500");
+    expect(document.querySelector("svg")).toHaveAttribute("height", "195");
+    expect(screen.getByTestId("stars")).toHaveTextContent("100");
+    expect(screen.getByTestId("commits")).toHaveTextContent("200");
+    expect(screen.getByTestId("issues")).toHaveTextContent("300");
+    expect(screen.getByTestId("prs")).toHaveTextContent("400");
+    expect(screen.getByTestId("contribs")).toHaveTextContent("500");
     expect(screen.queryByTestId("card-bg")).toBeInTheDocument();
     expect(screen.queryByTestId("rank-circle")).toBeInTheDocument();
 
@@ -62,13 +60,13 @@ describe("Test renderStatsCard", () => {
   it("should have proper name apostrophe", () => {
     document.body.innerHTML = renderStatsCard({ ...stats, name: "Anil Das" });
 
-    expect(document.querySelector(".header")?.textContent).toBe(
+    expect(document.querySelector(".header")).toHaveTextContent(
       "Anil Das' GitHub Stats",
     );
 
     document.body.innerHTML = renderStatsCard({ ...stats, name: "Felix" });
 
-    expect(document.querySelector(".header")?.textContent).toBe(
+    expect(document.querySelector(".header")).toHaveTextContent(
       "Felix's GitHub Stats",
     );
   });
@@ -78,20 +76,23 @@ describe("Test renderStatsCard", () => {
       hide: ["issues", "prs", "contribs"],
     });
 
-    expect(document.body.querySelector("svg")?.getAttribute("height")).toBe(
-      "150",
-    ); // height should be 150 because we clamped it.
+    // height should be 150 because we clamped it.
+    expect(document.querySelector("svg")).toHaveAttribute("height", "150");
 
-    expect(screen.queryByTestId("stars")).toBeDefined();
-    expect(screen.queryByTestId("commits")).toBeDefined();
-    expect(screen.queryByTestId("issues")).toBeNull();
-    expect(screen.queryByTestId("prs")).toBeNull();
-    expect(screen.queryByTestId("contribs")).toBeNull();
-    expect(screen.queryByTestId("reviews")).toBeNull();
-    expect(screen.queryByTestId("discussions_started")).toBeNull();
-    expect(screen.queryByTestId("discussions_answered")).toBeNull();
-    expect(screen.queryByTestId("prs_merged")).toBeNull();
-    expect(screen.queryByTestId("prs_merged_percentage")).toBeNull();
+    expect(screen.queryByTestId("stars")).toBeInTheDocument();
+    expect(screen.queryByTestId("commits")).toBeInTheDocument();
+    expect(screen.queryByTestId("issues")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("prs")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("contribs")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("reviews")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("discussions_started")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("discussions_answered"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("prs_merged")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("prs_merged_percentage"),
+    ).not.toBeInTheDocument();
   });
 
   it("should show additional stats", () => {
@@ -105,20 +106,18 @@ describe("Test renderStatsCard", () => {
       ],
     });
 
-    expect(document.body.querySelector("svg")?.getAttribute("height")).toBe(
-      "320",
-    );
+    expect(document.querySelector("svg")).toHaveAttribute("height", "320");
 
-    expect(screen.queryByTestId("stars")).toBeDefined();
-    expect(screen.queryByTestId("commits")).toBeDefined();
-    expect(screen.queryByTestId("issues")).toBeDefined();
-    expect(screen.queryByTestId("prs")).toBeDefined();
-    expect(screen.queryByTestId("contribs")).toBeDefined();
-    expect(screen.queryByTestId("reviews")).toBeDefined();
-    expect(screen.queryByTestId("discussions_started")).toBeDefined();
-    expect(screen.queryByTestId("discussions_answered")).toBeDefined();
-    expect(screen.queryByTestId("prs_merged")).toBeDefined();
-    expect(screen.queryByTestId("prs_merged_percentage")).toBeDefined();
+    expect(screen.queryByTestId("stars")).toBeInTheDocument();
+    expect(screen.queryByTestId("commits")).toBeInTheDocument();
+    expect(screen.queryByTestId("issues")).toBeInTheDocument();
+    expect(screen.queryByTestId("prs")).toBeInTheDocument();
+    expect(screen.queryByTestId("contribs")).toBeInTheDocument();
+    expect(screen.queryByTestId("reviews")).toBeInTheDocument();
+    expect(screen.queryByTestId("discussions_started")).toBeInTheDocument();
+    expect(screen.queryByTestId("discussions_answered")).toBeInTheDocument();
+    expect(screen.queryByTestId("prs_merged")).toBeInTheDocument();
+    expect(screen.queryByTestId("prs_merged_percentage")).toBeInTheDocument();
   });
 
   it("should hide_rank", () => {
@@ -334,8 +333,8 @@ describe("Test renderStatsCard", () => {
     });
 
     const stars = screen.getByTestId("stars");
-    expect(screen.queryAllByTestId("icon")[0]).toBeDefined();
-    expect(stars).toBeDefined();
+    expect(screen.queryAllByTestId("icon")[0]).toBeInTheDocument();
+    expect(stars).toBeInTheDocument();
     // the label
     expect(stars.previousElementSibling).toHaveAttribute("x", "25");
   });
@@ -344,8 +343,8 @@ describe("Test renderStatsCard", () => {
     document.body.innerHTML = renderStatsCard(stats, { show_icons: false });
 
     const stars = screen.getByTestId("stars");
-    expect(screen.queryAllByTestId("icon")[0]).not.toBeDefined();
-    expect(stars).toBeDefined();
+    expect(screen.queryAllByTestId("icon")).toHaveLength(0);
+    expect(stars).toBeInTheDocument();
     // the label
     expect(stars.previousElementSibling).not.toHaveAttribute("x");
   });
@@ -355,7 +354,8 @@ describe("Test renderStatsCard", () => {
       hide_rank: true,
     });
 
-    expect(document.body.querySelector("svg")?.getAttribute("width")).toBe(
+    expect(document.querySelector("svg")).toHaveAttribute(
+      "width",
       "299.9666657447815",
     );
   });
@@ -366,41 +366,39 @@ describe("Test renderStatsCard", () => {
       custom_title: "Hello world",
     });
 
-    expect(document.body.querySelector("svg")?.getAttribute("width")).toBe(
-      "287",
-    );
+    expect(document.querySelector("svg")).toHaveAttribute("width", "287");
   });
 
   it("should render translations", () => {
     document.body.innerHTML = renderStatsCard(stats, { locale: "cn" });
-    expect(document.querySelector(".header")?.textContent).toBe(
+    expect(document.querySelector(".header")).toHaveTextContent(
       "Anurag Hazra 的 GitHub 统计数据",
     );
     expect(
       document.querySelector(
         'g[transform="translate(0, 0)"]>.stagger>.stat.bold',
-      )?.textContent,
-    ).toMatchInlineSnapshot(`"获标星数:"`);
+      ),
+    ).toHaveTextContent("获标星数:");
     expect(
       document.querySelector(
         'g[transform="translate(0, 25)"]>.stagger>.stat.bold',
-      )?.textContent,
-    ).toMatchInlineSnapshot(`"累计提交总数 (去年):"`);
+      ),
+    ).toHaveTextContent("累计提交总数 (去年):");
     expect(
       document.querySelector(
         'g[transform="translate(0, 50)"]>.stagger>.stat.bold',
-      )?.textContent,
-    ).toMatchInlineSnapshot(`"发起的 PR 总数:"`);
+      ),
+    ).toHaveTextContent("发起的 PR 总数:");
     expect(
       document.querySelector(
         'g[transform="translate(0, 75)"]>.stagger>.stat.bold',
-      )?.textContent,
-    ).toMatchInlineSnapshot(`"提出的 issue 总数:"`);
+      ),
+    ).toHaveTextContent("提出的 issue 总数:");
     expect(
       document.querySelector(
         'g[transform="translate(0, 100)"]>.stagger>.stat.bold',
-      )?.textContent,
-    ).toMatchInlineSnapshot(`"贡献的项目数（去年）:"`);
+      ),
+    ).toHaveTextContent("贡献的项目数（去年）:");
   });
 
   it("should render without rounding", () => {
@@ -414,44 +412,44 @@ describe("Test renderStatsCard", () => {
     stats.totalCommits = 1999;
 
     document.body.innerHTML = renderStatsCard(stats);
-    expect(screen.getByTestId("commits").textContent).toBe("2k");
+    expect(screen.getByTestId("commits")).toHaveTextContent("2k");
     document.body.innerHTML = renderStatsCard(stats, { number_format: "long" });
-    expect(screen.getByTestId("commits").textContent).toBe("1999");
+    expect(screen.getByTestId("commits")).toHaveTextContent("1999");
     document.body.innerHTML = renderStatsCard(stats, { number_precision: 2 });
-    expect(screen.getByTestId("commits").textContent).toBe("2.00k");
+    expect(screen.getByTestId("commits")).toHaveTextContent("2.00k");
     document.body.innerHTML = renderStatsCard(stats, {
       number_format: "long",
       number_precision: 2,
     });
-    expect(screen.getByTestId("commits").textContent).toBe("1999");
+    expect(screen.getByTestId("commits")).toHaveTextContent("1999");
   });
 
   it("should render default rank icon with level A+", () => {
     document.body.innerHTML = renderStatsCard(stats, {
       rank_icon: "default",
     });
-    const levelRankIcon = screen.getByTestId("level-rank-icon");
-    expect(levelRankIcon).toBeDefined();
-    expect(levelRankIcon.textContent.trim()).toBe("A+");
+    expect(screen.getByTestId("level-rank-icon")).toHaveTextContent("A+");
   });
 
   it("should render github rank icon", () => {
     document.body.innerHTML = renderStatsCard(stats, {
       rank_icon: "github",
     });
-    expect(screen.queryByTestId("github-rank-icon")).toBeDefined();
+    expect(screen.queryByTestId("github-rank-icon")).toBeInTheDocument();
   });
 
   it("should show the rank percentile", () => {
     document.body.innerHTML = renderStatsCard(stats, {
       rank_icon: "percentile",
     });
-    const percentileTopHeader = screen.getByTestId("percentile-top-header");
-    expect(percentileTopHeader).toBeDefined();
-    expect(percentileTopHeader.textContent.trim()).toBe("Top");
-    expect(screen.queryByTestId("rank-percentile-text")).toBeDefined();
-    expect(screen.getByTestId("percentile-rank-value").textContent.trim()).toBe(
-      stats.rank.percentile.toFixed(1) + "%",
+    expect(screen.getByTestId("percentile-top-header")).toHaveTextContent(
+      "Top",
+    );
+
+    const percentileRankValue = screen.getByTestId("percentile-rank-value");
+    expect(percentileRankValue).toHaveClass("rank-percentile-text");
+    expect(percentileRankValue).toHaveTextContent(
+      `${stats.rank.percentile.toFixed(1)}%`,
     );
   });
 

--- a/packages/core/tests/renderTopLanguagesCard.test.ts
+++ b/packages/core/tests/renderTopLanguagesCard.test.ts
@@ -398,7 +398,7 @@ describe("Test renderTopLanguages", () => {
     let langNames = screen.queryAllByTestId("lang-name");
     expect(langNames[0]).toBeInTheDocument();
     expect(langNames[1]).toBeInTheDocument();
-    expect(langNames[2]).not.toBeDefined();
+    expect(langNames).toHaveLength(2);
 
     // multiple languages passed
     document.body.innerHTML = renderTopLanguages(langs, {
@@ -406,7 +406,7 @@ describe("Test renderTopLanguages", () => {
     });
     langNames = screen.queryAllByTestId("lang-name");
     expect(langNames[0]).toBeInTheDocument();
-    expect(langNames[1]).not.toBeDefined();
+    expect(langNames).toHaveLength(1);
   });
 
   it("should resize the height correctly depending on langs", () => {
@@ -493,10 +493,9 @@ describe("Test renderTopLanguages", () => {
     expect(progressBgStyles?.["fill"]?.trim()).toBe(`#${prog_bar_bg_color}`);
     expect(screen.queryByTestId("card-bg")).toHaveAttribute("fill", "#252525");
 
-    const progressBackgroundNodes = screen.queryAllByTestId(
-      "progress-background",
-    );
-    expect(progressBackgroundNodes.length).toBeGreaterThan(0);
+    expect(
+      screen.queryAllByTestId("progress-background").length,
+    ).toBeGreaterThan(0);
   });
 
   it("should render custom colors with themes", () => {
@@ -749,7 +748,7 @@ describe("Test renderTopLanguages", () => {
 
   it("should render a translated title", () => {
     document.body.innerHTML = renderTopLanguages(langs, { locale: "cn" });
-    expect(document.querySelector(".header")?.textContent).toBe("最常用的语言");
+    expect(document.querySelector(".header")).toHaveTextContent("最常用的语言");
   });
 
   it("should render without rounding", () => {
@@ -764,7 +763,7 @@ describe("Test renderTopLanguages", () => {
       langs_count: 1,
     };
     document.body.innerHTML = renderTopLanguages(langs, { ...options });
-    expect(screen.queryAllByTestId("lang-name").length).toBe(
+    expect(screen.queryAllByTestId("lang-name")).toHaveLength(
       options.langs_count,
     );
   });
@@ -775,14 +774,14 @@ describe("Test renderTopLanguages", () => {
       langs_count: 2,
     };
     document.body.innerHTML = renderTopLanguages(langs, { ...options });
-    expect(screen.queryAllByTestId("lang-name").length).toBe(
+    expect(screen.queryAllByTestId("lang-name")).toHaveLength(
       options.langs_count,
     );
   });
 
   it('should show "No languages data." message instead of empty card when nothing to show', () => {
     document.body.innerHTML = renderTopLanguages({});
-    expect(document.querySelector(".stat")?.textContent).toBe(
+    expect(document.querySelector(".stat")).toHaveTextContent(
       "No languages data.",
     );
   });
@@ -827,7 +826,7 @@ describe("Test renderTopLanguages", () => {
 
     const langNames = screen.queryAllByTestId("lang-name");
     expect(langNames[0]).toHaveTextContent("HTML");
-    expect(langNames.length).toBe(3);
+    expect(langNames).toHaveLength(3);
   });
 
   it("should hide stats values when hide_values is true (donut layout)", () => {

--- a/packages/core/tests/renderWakatimeCard.test.js
+++ b/packages/core/tests/renderWakatimeCard.test.js
@@ -1,4 +1,4 @@
-import { queryByTestId } from "@testing-library/dom";
+import { screen } from "@testing-library/dom";
 import { describe, expect, it } from "vitest";
 
 import wakatimeApi from "../src/api/wakatime.js";
@@ -32,20 +32,19 @@ describe("Test Render WakaTime Card", () => {
       hide: ["YAML", "Other"],
     });
 
-    expect(queryByTestId(document.body, /YAML/i)).toBeNull();
-    expect(queryByTestId(document.body, /Other/i)).toBeNull();
-    expect(queryByTestId(document.body, /TypeScript/i)).not.toBeNull();
+    expect(screen.queryByTestId(/YAML/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/Other/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/TypeScript/i)).toBeInTheDocument();
   });
 
   it("should render translations", () => {
     document.body.innerHTML = renderWakatimeCard({}, { locale: "cn" });
-    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+    expect(document.querySelector(".header")).toHaveTextContent(
       "WakaTime 周统计",
     );
     expect(
-      document.querySelector('g[transform="translate(0, 0)"]>text.stat.bold')
-        .textContent,
-    ).toBe("WakaTime 用户个人资料未公开");
+      document.querySelector('g[transform="translate(0, 0)"]>text.stat.bold'),
+    ).toHaveTextContent("WakaTime 用户个人资料未公开");
   });
 
   it("should render without rounding", () => {
@@ -65,7 +64,7 @@ describe("Test Render WakaTime Card", () => {
       },
       {},
     );
-    expect(document.querySelector(".stat").textContent).toBe(
+    expect(document.querySelector(".stat")).toHaveTextContent(
       "No coding activity this week",
     );
   });
@@ -80,7 +79,7 @@ describe("Test Render WakaTime Card", () => {
         layout: "compact",
       },
     );
-    expect(document.querySelector(".stat").textContent).toBe(
+    expect(document.querySelector(".stat")).toHaveTextContent(
       "No coding activity this week",
     );
   });


### PR DESCRIPTION
- Card tests now assert with jest-dom matchers instead of reading nodes by hand:
  `toHaveTextContent`, `toHaveAttribute`, `toHaveStyle`, `toBeInTheDocument`.
- Fixes assertions in `renderStatsCard.test.ts`: 
  `queryByTestId` returns `null`, so `toBeDefined()` could never fail. 
  One of them was checking `rank-percentile-text`, which is a CSS class and not a test id.
- Index-existence checks became `toHaveLength(n)`; 
- The five `toMatchInlineSnapshot` translation checks became explicit `toHaveTextContent` with the same strings.
- `renderWakatimeCard.test.js` moved to the `screen` API
- `card.test.ts` uses `querySelector` over `getElementsBy*`.