### PR TITLE
fix: keep tests out of the build output and disable `tsc` emit by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ apps/frontend/.env
 
 .turbo
 build
-build-ts
 *.tsbuildinfo
 
 # IDE

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -7,7 +7,6 @@
     "vitest.config.e2e.ts"
   ],
   "compilerOptions": {
-    "composite": true,
     "module": "nodenext",
     "moduleResolution": "nodenext"
   }

--- a/apps/backend/tsconfig.typecheck.json
+++ b/apps/backend/tsconfig.typecheck.json
@@ -1,7 +1,6 @@
 {
   "extends": ["./tsconfig.json"],
   "compilerOptions": {
-    "noEmit": true,
     "customConditions": []
   }
 }

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -9,10 +9,8 @@
   ],
   "compilerOptions": {
     "lib": ["DOM"],
-    "composite": true,
     "module": "esnext",
     "moduleResolution": "bundler",
-    "outDir": "./build-ts",
     "resolveJsonModule": true
   }
 }

--- a/apps/frontend/tsconfig.typecheck.json
+++ b/apps/frontend/tsconfig.typecheck.json
@@ -1,7 +1,6 @@
 {
   "extends": ["./tsconfig.json"],
   "compilerOptions": {
-    "noEmit": true,
     "customConditions": []
   }
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,7 +2,9 @@
   "extends": ["./tsconfig.json"],
   "include": ["src"],
   "compilerOptions": {
+    "noEmit": false,
     "rootDir": "./src",
+    "outDir": "./build",
     "declaration": true,
     "declarationMap": true,
     "customConditions": [],

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,7 +5,6 @@
     "allowJs": true,
 
     "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "outDir": "build"
+    "moduleResolution": "nodenext"
   }
 }

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -1,7 +1,6 @@
 {
   "extends": ["./tsconfig.json"],
   "compilerOptions": {
-    "noEmit": true,
     "customConditions": []
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,10 @@
       "@stats/source"
     ],
 
+    // Emit
+    // Off by default so no `tsc` writes output unless explicitly opted in
+    "noEmit": true,
+
     // Interop Constraints
     "verbatimModuleSyntax": true,
     "isolatedModules": true,

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base.json",
   "include": ["scripts"],
   "compilerOptions": {
-    "noEmit": true,
     "customConditions": [],
     // Base config sets `types: []`; these scripts run on node
     "types": ["node"]


### PR DESCRIPTION
- `packages/core/tsconfig.json` covers `tests` but also set `outDir: "build"`,
  so a simple `tsc` emitted `build/tests`, which turbo then cached and replayed on every later build.
- `tsconfig.base.json` now sets `noEmit: true`;
  `packages/core/tsconfig.build.json` is the only config that opts back in, and it takes the `outDir`.
- Removed `noEmit` from the typecheck and scripts configs.
- Removed `composite: true` from both apps: nothing references them as TypeScript projects.

> [!NOTE]
>  Local-only issue: CI never runs a standalone `tsc` and starts from a clean checkout, 
>  so the polluted `build/` never showed up there.