### PR TITLE
fix(retryer): retry transient network errors with backoff

### DIFF
--- a/apps/backend/tests/status.up.test.js
+++ b/apps/backend/tests/status.up.test.js
@@ -209,7 +209,16 @@ describe("Test /api/status/up", () => {
     mock.onPost("https://api.github.com/graphql").networkError();
 
     const { req, res } = faker({}, {});
-    await up(req, res);
+    // the retryer sleeps through its transient-backoff schedule
+    // (2 PATs x [1s, 2s, 4s] + jitter) before giving up
+    vi.useFakeTimers();
+    try {
+      const pending = up(req, res);
+      await vi.advanceTimersByTimeAsync(20_000);
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(res.setHeader).toHaveBeenCalledWith(
       "Content-Type",
@@ -234,7 +243,16 @@ describe("Test /api/status/up", () => {
     mock.onPost("https://api.github.com/graphql").networkError();
 
     const { req, res } = faker({}, {});
-    await up(req, res);
+    // the retryer sleeps through its transient-backoff schedule
+    // (2 PATs x [1s, 2s, 4s] + jitter) before giving up
+    vi.useFakeTimers();
+    try {
+      const pending = up(req, res);
+      await vi.advanceTimersByTimeAsync(20_000);
+      await pending;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(res.setHeader.mock.calls).toEqual([
       ["Content-Type", "application/json"],

--- a/packages/core/src/common/retryer.ts
+++ b/packages/core/src/common/retryer.ts
@@ -29,6 +29,45 @@ function getRandomInt(max: number): number {
 }
 
 /**
+ * Delay before each transient retry of the same PAT.
+ *
+ * Transient failures are network-level errors (ECONNRESET, ETIMEDOUT,
+ * socket hang up) and retryable HTTP statuses. Token rotation stays
+ * separate from this backoff.
+ */
+const TRANSIENT_RETRY_DELAYS_MS = [1000, 2000, 4000];
+
+/** Random extra wait added to each transient retry delay. */
+const TRANSIENT_RETRY_JITTER_MS = 250;
+
+/**
+ * HTTP statuses worth a same-token retry. Server-side blips only.
+ * 429 and rate-limit 403 answers skip quick retries entirely: hammering a
+ * limited token violates GitHub's Retry-After / reset guidance and can get
+ * the token blocked. Permanent statuses such as 401/404/422 stay outside
+ * this set.
+ */
+const RETRYABLE_HTTP_STATUS_CODES = new Set([502, 503, 504]);
+
+/**
+ * Wait for `ms` milliseconds.
+ */
+const sleep = (ms: number): Promise<void> => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+/**
+ * Optional overrides for {@link retryer}, mainly for tests.
+ */
+interface RetryerOptions {
+  /**
+   * Delays between transient retries of one PAT.
+   * An empty array disables transient retries.
+   */
+  transientRetryDelaysMs?: Array<number>;
+}
+
+/**
  * A fetcher's Axios response. `TData` is the shape of `response.data`,
  * which is intersected with {@link ResponseErrors} so the retryer can inspect
  * `errors`/`message`.
@@ -56,6 +95,7 @@ const retryer = async <TData = unknown, TVariables = Record<string, unknown>>(
   fetcher: FetcherFunction<TData, TVariables>,
   variables: TVariables,
   pat: string | null = null,
+  { transientRetryDelaysMs = TRANSIENT_RETRY_DELAYS_MS }: RetryerOptions = {},
 ): Promise<FetcherResponse<TData>> => {
   const PATs = pat
     ? [{ name: "user PAT from database", value: pat }]
@@ -66,59 +106,113 @@ const retryer = async <TData = unknown, TVariables = Record<string, unknown>>(
   }
   const startPAT = getRandomInt(PATs.length);
 
+  let lastTransientError: unknown = null;
+
   for (let retries = 0; retries < PATs.length; retries++) {
     const currentPAT = PATs[(startPAT + retries) % PATs.length];
     if (!currentPAT) {
       continue;
     }
 
-    try {
-      const response = await fetcher(
-        variables,
-        currentPAT.value,
-        // used in tests for faking rate limit
-        retries,
-      );
+    // One transient retry per delay entry. The last pass has no delay left
+    // and rotates to the next PAT instead.
+    for (let attempt = 0; attempt <= transientRetryDelaysMs.length; attempt++) {
+      try {
+        const response = await fetcher(
+          variables,
+          currentPAT.value,
+          // used in tests for faking rate limit
+          retries,
+        );
 
-      // react on both type and message-based rate-limit signals.
-      // https://github.com/anuraghazra/github-readme-stats/issues/4425
-      const errors = response.data.errors;
-      const errorType = errors?.[0]?.type;
-      const errorMsg = errors?.[0]?.message ?? "";
-      const isRateLimited =
-        (!!errors && errorType === "RATE_LIMITED") ||
-        /rate limit/i.test(errorMsg);
+        // react on both type and message-based rate-limit signals.
+        // https://github.com/anuraghazra/github-readme-stats/issues/4425
+        const errors = response.data.errors;
+        const errorType = errors?.[0]?.type;
+        const errorMsg = errors?.[0]?.message ?? "";
+        const isRateLimited =
+          (!!errors && errorType === "RATE_LIMITED") ||
+          /rate limit/i.test(errorMsg);
 
-      if (isRateLimited) {
-        logger.log(`${currentPAT.name} Failed due to rate limiting`);
-      } else {
+        if (isRateLimited) {
+          logger.log(`${currentPAT.name} Failed due to rate limiting`);
+          break; // rotate to next PAT
+        }
         return response;
-      }
-    } catch (err) {
-      const e = err as { response?: FetcherResponse<TData> };
+      } catch (err) {
+        const e = err as {
+          response?: FetcherResponse<TData>;
+          isAxiosError?: boolean;
+          message?: unknown;
+        };
 
-      // network/unexpected error → let caller treat as failure
-      if (!e.response) {
-        throw err;
-      }
+        // Rate-limit responses never get quick retries. Quick retries would
+        // violate GitHub's Retry-After / reset guidance and can get the
+        // token blocked, so rotate to the next PAT instead. HTTP 429 and
+        // rate-limit 403 answers both carry this meaning.
+        const status = e.response?.status;
+        const carriesRateLimitMessage = /rate limit/i.test(
+          e.response?.data.message ?? "",
+        );
+        const isRateLimitResponse =
+          status === 429 || (status === 403 && carriesRateLimitMessage);
 
-      // also checking for bad credentials if any tokens gets invalidated
-      const message = e.response.data.message;
-      const isBadCredential = message === "Bad credentials";
-      const isAccountSuspended =
-        message === "Sorry. Your account was suspended.";
+        if (isRateLimitResponse && e.response) {
+          logger.log(
+            `${currentPAT.name} hit a rate limit (HTTP ${status}), rotating`,
+          );
+          break; // rotate to next PAT
+        }
 
-      if (isBadCredential || isAccountSuspended) {
-        logger.log(`${currentPAT.name} Failed due to bad credentials`);
-      } else {
+        // Transient failure: network-level error without a response, or a
+        // retryable HTTP status. Retry the same PAT with backoff before
+        // rotating to the next token.
+        const isTransient =
+          (!e.response && e.isAxiosError === true) ||
+          (!!e.response && RETRYABLE_HTTP_STATUS_CODES.has(e.response.status));
+
+        if (isTransient) {
+          lastTransientError = err;
+          const delayMs = transientRetryDelaysMs[attempt];
+          if (delayMs !== undefined) {
+            logger.log(
+              `${currentPAT.name} transient failure (${String(e.message)}), retrying`,
+            );
+            await sleep(delayMs + getRandomInt(TRANSIENT_RETRY_JITTER_MS));
+            continue;
+          }
+          break; // retries exhausted → rotate to next PAT
+        }
+
+        // non-axios errors are bugs, not transient failures
+        if (!e.response) {
+          throw err;
+        }
+
+        // also checking for bad credentials if any tokens gets invalidated
+        const message = e.response.data.message;
+        const isBadCredential = message === "Bad credentials";
+        const isAccountSuspended =
+          message === "Sorry. Your account was suspended.";
+
+        if (isBadCredential || isAccountSuspended) {
+          logger.log(`${currentPAT.name} Failed due to bad credentials`);
+          break; // rotate to next PAT
+        }
+
         // HTTP error with a response → return it for caller-side handling
         return e.response;
       }
     }
   }
 
+  // Rate-limit rotation exhaustion keeps the historical message. Transient
+  // exhaustion reports the real cause, since claiming "rate limiting" would
+  // mislead when no rate limit was observed.
   throw new CustomError(
-    "Downtime due to GitHub API rate limiting",
+    lastTransientError instanceof Error
+      ? `GitHub API request failed after transient retries: ${lastTransientError.message}`
+      : "Downtime due to GitHub API rate limiting",
     CustomError.MAX_RETRY,
   );
 };

--- a/packages/core/tests/retryer.test.ts
+++ b/packages/core/tests/retryer.test.ts
@@ -44,6 +44,20 @@ const customFetcher = vi.fn((_variables: unknown, token: string) => {
   return Promise.resolve({ data: { token } });
 }) as unknown as Fetcher;
 
+const networkError = (): Error => {
+  return Object.assign(new Error("network error"), {
+    isAxiosError: true,
+    code: "ECONNRESET",
+  });
+};
+
+const httpError = (status: number, message = ""): Error => {
+  return Object.assign(new Error("http error"), {
+    isAxiosError: true,
+    response: { status, data: { message } },
+  });
+};
+
 describe("Test Retryer", () => {
   it("retryer should return value and have zero retries on first try", async () => {
     const res = await retryer(fetcher, {});
@@ -83,5 +97,111 @@ describe("Test Retryer", () => {
       0,
     );
     expect(res).toStrictEqual({ data: { token: "user-pat-token" } });
+  });
+
+  it("retryer should retry transient network errors on the same PAT", async () => {
+    const fetcherTransient = vi
+      .fn()
+      .mockRejectedValueOnce(networkError())
+      .mockResolvedValue({ data: "ok" }) as unknown as Fetcher;
+
+    const res = await retryer(fetcherTransient, {}, "user-pat-token", {
+      transientRetryDelaysMs: [0],
+    });
+
+    expect(fetcherTransient).toHaveBeenCalledTimes(2);
+    expect(res).toStrictEqual({ data: "ok" });
+  });
+
+  it.each([
+    [502, true],
+    [503, true],
+    [504, true],
+    // a rate limit: rotate instead of quick-retrying
+    [429, false],
+  ])("HTTP %i: quick retry = %s", async (status, shouldRetry) => {
+    const fetcherByStatus = vi
+      .fn()
+      .mockRejectedValueOnce(httpError(status))
+      .mockResolvedValue({ data: "ok" });
+
+    if (shouldRetry) {
+      const res = await retryer(
+        fetcherByStatus as unknown as Fetcher,
+        {},
+        "user-pat-token",
+        { transientRetryDelaysMs: [0] },
+      );
+
+      expect(fetcherByStatus).toHaveBeenCalledTimes(2);
+      expect(res).toStrictEqual({ data: "ok" });
+    } else {
+      await expect(
+        retryer(fetcherByStatus as unknown as Fetcher, {}, "user-pat-token", {
+          transientRetryDelaysMs: [0],
+        }),
+      ).rejects.toThrow("Downtime due to GitHub API rate limiting");
+
+      expect(fetcherByStatus).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("retryer should treat a rate-limit 403 like a rate limit", async () => {
+    const fetcher403 = vi
+      .fn()
+      .mockRejectedValue(httpError(403, "API rate limit exceeded for ..."));
+
+    await expect(
+      retryer(fetcher403 as unknown as Fetcher, {}, "user-pat-token", {
+        transientRetryDelaysMs: [0],
+      }),
+    ).rejects.toThrow("Downtime due to GitHub API rate limiting");
+
+    expect(fetcher403).toHaveBeenCalledTimes(1);
+  });
+
+  it("retryer should not retry non-retryable HTTP statuses", async () => {
+    const fetcher404 = vi.fn().mockRejectedValue(httpError(404, "Not Found"));
+
+    const res = await retryer(
+      fetcher404 as unknown as Fetcher,
+      {},
+      "user-pat-token",
+      { transientRetryDelaysMs: [0] },
+    );
+
+    expect(fetcher404).toHaveBeenCalledTimes(1);
+    expect(res).toStrictEqual({ status: 404, data: { message: "Not Found" } });
+  });
+
+  it("retryer should throw non-axios errors immediately without retrying", async () => {
+    const fetcherBug = vi
+      .fn()
+      .mockRejectedValue(new TypeError("boom")) as unknown as Fetcher;
+
+    await expect(
+      retryer(fetcherBug, {}, "user-pat-token", {
+        transientRetryDelaysMs: [0],
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(fetcherBug).toHaveBeenCalledTimes(1);
+  });
+
+  it("retryer should report the transient cause without claiming rate limiting", async () => {
+    const fetcherAlwaysFails = vi.fn().mockRejectedValue(networkError());
+
+    const promise = retryer(
+      fetcherAlwaysFails as unknown as Fetcher,
+      {},
+      "user-pat-token",
+      { transientRetryDelaysMs: [] },
+    );
+
+    await expect(promise).rejects.toThrow(
+      "GitHub API request failed after transient retries: network error",
+    );
+    await expect(promise).rejects.not.toThrow(/rate limiting/i);
+    expect(fetcherAlwaysFails).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Fixes #508

## What

`retryer()` now separates token rotation from transient retry:

- Each PAT gets an inner retry with exponential backoff (`1s, 2s, 4s`) plus jitter before rotation moves to the next token.
- A failure is transient when the error has no response (network level: `ECONNRESET`, `ETIMEDOUT`, socket hang up, DNS failures) or when the HTTP status is 502/503/504.
- Rate-limit responses (HTTP 429, or 403 carrying a rate-limit message) skip quick retries entirely and rotate to the next PAT, avoiding violations of GitHub Retry-After / reset guidance.
- Permanent failures keep their behavior: bad credentials and suspended accounts rotate to the next PAT; non-axios errors and other HTTP errors are returned or thrown immediately.
- Existing call sites remain backward-compatible. A new optional options parameter allows retry delays to be overridden for tests.

## Final error message

Exhaustion now reports the real cause instead of always claiming rate limiting:

```text
// transient exhaustion (no rate limit observed):
GitHub API request failed after transient retries: connect ECONNRESET 140.82.x.x:443

// genuine rate-limit rotation exhaustion (unchanged):
Downtime due to GitHub API rate limiting
```

The `MAX_RETRY` type is kept, so `secondaryMessage` mapping stays the same.

## Tests

- New cases in `packages/core/tests/retryer.test.ts`: same-PAT retry after a network error, retry on 502, no retry on 404, immediate throw for non-axios errors, accurate message on transient exhaustion, and no "rate limiting" claim when only transient errors occurred.
- `apps/backend/tests/status.up.test.js`: the two `networkError` tests now use fake timers to advance the backoff schedule.

Full suite: 728 passed. Retryer status handling is covered by a parameterized matrix (502/503/504 quick retry, 429 rotate).

