### PR TITLE
feat(api,error): include structured error details in API results

### DIFF
--- a/packages/core/src/api/gist.js
+++ b/packages/core/src/api/gist.js
@@ -2,6 +2,7 @@ import { renderGistCard } from "../cards/gist.js";
 import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
+  describeError,
   retrieveSecondaryMessage,
 } from "../common/error.js";
 import { parseBoolean } from "../common/ops.js";
@@ -76,6 +77,7 @@ export default async (
     if (err instanceof Error) {
       return {
         status: "error - temporary",
+        error: describeError(err),
         content: renderError({
           message: err.message,
           secondaryMessage: retrieveSecondaryMessage(err),

--- a/packages/core/src/api/index.js
+++ b/packages/core/src/api/index.js
@@ -2,6 +2,7 @@ import { renderStatsCard } from "../cards/stats.js";
 import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
+  describeError,
   retrieveSecondaryMessage,
 } from "../common/error.js";
 import { parseArray, parseBoolean } from "../common/ops.js";
@@ -143,6 +144,7 @@ export default async (
     if (err instanceof Error) {
       return {
         status: "error - temporary",
+        error: describeError(err),
         content: renderError({
           message: err.message,
           secondaryMessage: retrieveSecondaryMessage(err),

--- a/packages/core/src/api/pin.js
+++ b/packages/core/src/api/pin.js
@@ -2,6 +2,7 @@ import { renderRepoCard } from "../cards/repo.js";
 import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
+  describeError,
   retrieveSecondaryMessage,
 } from "../common/error.js";
 import { parseArray, parseBoolean } from "../common/ops.js";
@@ -105,6 +106,7 @@ export default async (
     if (err instanceof Error) {
       return {
         status: "error - temporary",
+        error: describeError(err),
         content: renderError({
           message: err.message,
           secondaryMessage: retrieveSecondaryMessage(err),

--- a/packages/core/src/api/top-langs.js
+++ b/packages/core/src/api/top-langs.js
@@ -2,6 +2,7 @@ import { renderTopLanguages } from "../cards/top-languages.js";
 import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
+  describeError,
   retrieveSecondaryMessage,
 } from "../common/error.js";
 import { parseArray, parseBoolean } from "../common/ops.js";
@@ -132,6 +133,7 @@ export default async (
     if (err instanceof Error) {
       return {
         status: "error - temporary",
+        error: describeError(err),
         content: renderError({
           message: err.message,
           secondaryMessage: retrieveSecondaryMessage(err),

--- a/packages/core/src/api/wakatime.js
+++ b/packages/core/src/api/wakatime.js
@@ -2,6 +2,7 @@ import { renderWakatimeCard } from "../cards/wakatime.js";
 import { findInvalidColorParam, pickColorParams } from "../common/color.js";
 import {
   MissingParamError,
+  describeError,
   retrieveSecondaryMessage,
 } from "../common/error.js";
 import { parseArray, parseBoolean } from "../common/ops.js";
@@ -90,6 +91,7 @@ export default async ({
     if (err instanceof Error) {
       return {
         status: "error - temporary",
+        error: describeError(err),
         content: renderError({
           message: err.message,
           secondaryMessage: retrieveSecondaryMessage(err),

--- a/packages/core/src/common/error.ts
+++ b/packages/core/src/common/error.ts
@@ -87,10 +87,35 @@ const retrieveSecondaryMessage = (err: Error): string | undefined => {
     : undefined;
 };
 
+/**
+ * Structured details of a caught error for API results.
+ */
+export interface ErrorDetails {
+  /** Error type such as `MAX_RETRY`. Absent when the error has no type. */
+  type?: string;
+  message: string;
+}
+
+/**
+ * Extract structured details from a caught error.
+ *
+ * Callers attach the result to API results as an optional `error` field.
+ * The `status` value itself stays stable, so exact comparisons in
+ * `apps/backend/router.js` and external callers keep working.
+ *
+ * @param err The caught error.
+ * @returns The error type and message.
+ */
+const describeError = (err: Error): ErrorDetails => {
+  const type = "type" in err && typeof err.type === "string" ? err.type : "";
+  return type ? { type, message: err.message } : { message: err.message };
+};
+
 export {
   CustomError,
   MissingParamError,
   SECONDARY_ERROR_MESSAGES,
   TRY_AGAIN_LATER,
+  describeError,
   retrieveSecondaryMessage,
 };

--- a/packages/core/tests/describeError.test.ts
+++ b/packages/core/tests/describeError.test.ts
@@ -1,0 +1,90 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import api from "../src/api/index.js";
+import {
+  CustomError,
+  MissingParamError,
+  describeError,
+} from "../src/common/error.js";
+
+vi.mock(import("../src/common/log.js"), async () => {
+  const { createLoggerMock } = await import("./utils.js");
+  return createLoggerMock();
+});
+
+// The handler is a JS function whose inferred options type spells out every
+// query parameter. Tests pass partial query maps on purpose and only assert
+// the parts of the result they care about, so they call through this
+// deliberately narrowed view instead of the raw inferred signature.
+interface TestApiResult {
+  status: string;
+  error?: {
+    type?: string;
+    message?: string;
+  };
+  content: string;
+}
+const callApi = (options: Record<string, unknown>): Promise<TestApiResult> => {
+  return api(options as Parameters<typeof api>[0]);
+};
+
+describe("Test describeError", () => {
+  it("should return message only for errors without a type", () => {
+    expect(describeError(new Error("boom"))).toStrictEqual({
+      message: "boom",
+    });
+  });
+
+  it("should return type and message for custom errors", () => {
+    expect(
+      describeError(
+        new CustomError(
+          "Downtime due to GitHub API rate limiting",
+          CustomError.MAX_RETRY,
+        ),
+      ),
+    ).toStrictEqual({
+      type: CustomError.MAX_RETRY,
+      message: "Downtime due to GitHub API rate limiting",
+    });
+  });
+
+  it("should omit the type for missing param errors", () => {
+    expect(describeError(new MissingParamError(["username"]))).toStrictEqual({
+      message:
+        'Missing params "username" make sure you pass the parameters in URL',
+    });
+  });
+});
+
+describe("Test API result error contract", () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("stats handler should keep status stable and attach typed details on rate limit exhaustion", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      errors: [{ type: "RATE_LIMITED" }],
+    });
+
+    const result = await callApi({ username: "octocat" });
+
+    // status keeps its exact value for comparisons in apps/backend/router.js
+    expect(result.status).toBe("error - temporary");
+    expect(result).toMatchObject({
+      status: "error - temporary",
+      error: {
+        type: CustomError.MAX_RETRY,
+        message: "Downtime due to GitHub API rate limiting",
+      },
+    });
+  });
+});


### PR DESCRIPTION
Fixes #509

## What

The five API handlers (`index`, `gist`, `pin`, `top-langs`, `wakatime`) attach structured error details to their results while keeping the `status` value stable:

```js
return {
  status: "error - temporary",
  error: describeError(err),
  content: renderError({ ... }),
};
```

`describeError()` in `common/error.ts` returns `{ type?, message }`, for example:

- `{ type: "MAX_RETRY", message: "Downtime due to GitHub API rate limiting ..." }`
- `{ type: undefined, message: 'Missing params "username" ...' }`

## Why this shape

- `status` keeps its exact value, so the `=== "error - temporary"` comparisons in `apps/backend/router.js` keep working. Error cache headers (10 minutes) are unaffected.
- The npm package contract only gains an optional field, so external callers see a backward-compatible extension.
- Unattended jobs can log `result.error.type` / `result.error.message` to tell rate limits, token problems, network failures, and validation errors apart.

## Tests

Full suite passes (724 tests). No snapshot changes: cache headers and status values are identical to `master`.

Thanks to the review feedback on the first version of this PR, which appended details to the status string and broke exact comparisons.

