### PR TITLE
chore(knip): remove redundant `express.js` from `apps/backend` entry

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -9,7 +9,7 @@
       "ignore": ["src/graphql/generated/**"]
     },
     "apps/backend": {
-      "entry": ["api-renamed/*.js", "express.js"]
+      "entry": ["api-renamed/*.js"]
     },
     "apps/frontend": {
       "entry": ["src/wakatime-override.ts"],


### PR DESCRIPTION
In  #489 I forgot to remove `express.js` from knip config.
The file is now referenced by the backend `dev` script:

https://github.com/stats-organization/github-stats-extended/blob/01f2468417189ab8a22b9dd80498d967fbf85c0d/apps/backend/package.json#L11