### PR TITLE
chore(dependabot): add astro group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,12 @@ updates:
         patterns:
           - "vite"
           - "@vitejs/*"
+      astro:
+        patterns:
+          - "astro"
+          - "astro-*"
+          - "@astrojs/*"
+          - "starlight-*"
       tailwind:
         patterns:
           - "tailwindcss"


### PR DESCRIPTION
- Adds one `astro` group in `.github/dependabot.yml`
- `@astrojs/starlight` and its plugins ride along with Astro core bumps, since a Starlight upgrade usually tracks the Astro version anyway.