### PR TITLE
all-time contributed-to, contribs to own repos refinements

### DIFF
--- a/apps/frontend/src/content/docs/docs/fork.md
+++ b/apps/frontend/src/content/docs/docs/fork.md
@@ -56,10 +56,10 @@ The pre-existing "Contributed to" stat counts repositories a user has contribute
 
 ### New options for "contributed-to" stats
 
-GitHub-Stats-Extended adds an `all_time_contribs` stat that shows the number of repositories a user has contributed to across all years — not just the past year like the default `contribs` stat. 
+GitHub-Stats-Extended adds an `all_time_contribs` stat that shows the number of repositories a user has contributed to across all years — not just the past year like the default `contribs` stat.
 Enable it with [`&show=all_time_contribs`](/frontend/docs/cards/stats/#showing-additional-individual-stats).
 
-GitHub-Stats-Extended also adds a parameter [`contribs_include_own_repos`](/frontend/docs/cards/stats/#options) to include the user's own repositories in the `contribs` and `all_time_contribs` stats. 
+GitHub-Stats-Extended also adds a parameter [`contribs_include_own_repos`](/frontend/docs/cards/stats/#options) to include the user's own repositories in the `contribs` and `all_time_contribs` stats.
 By default, both stats exclude them and only count repositories owned by other users or organizations.
 
 ### Customization of top languages card

--- a/apps/frontend/src/content/docs/docs/fork.md
+++ b/apps/frontend/src/content/docs/docs/fork.md
@@ -56,9 +56,11 @@ The pre-existing "Contributed to" stat counts repositories a user has contribute
 
 ### New options for "contributed-to" stats
 
-GitHub-Stats-Extended adds an `all_time_contribs` stat that shows the number of repositories a user has contributed to across all years — not just the past year like the default `contribs` stat. Enable it with [`&show=all_time_contribs`](/frontend/docs/cards/stats/#showing-additional-individual-stats).
+GitHub-Stats-Extended adds an `all_time_contribs` stat that shows the number of repositories a user has contributed to across all years — not just the past year like the default `contribs` stat. 
+Enable it with [`&show=all_time_contribs`](/frontend/docs/cards/stats/#showing-additional-individual-stats).
 
-GitHub-Stats-Extended also adds a parameter [`contribs_include_own_repos`](/frontend/docs/cards/stats/#options) to include the user's own repositories in the `contribs` and `all_time_contribs` stats. By default, both stats exclude them and only count repositories owned by other users or organizations.
+GitHub-Stats-Extended also adds a parameter [`contribs_include_own_repos`](/frontend/docs/cards/stats/#options) to include the user's own repositories in the `contribs` and `all_time_contribs` stats. 
+By default, both stats exclude them and only count repositories owned by other users or organizations.
 
 ### Customization of top languages card
 

--- a/packages/core/src/api/index.js
+++ b/packages/core/src/api/index.js
@@ -92,7 +92,7 @@ export default async (
       }),
     };
   }
-  const commitsYear =
+  const commitsYearParsed =
     commits_year === undefined ? undefined : Number(commits_year);
 
   try {
@@ -111,7 +111,7 @@ export default async (
         showStats.includes("prs_merged_percentage"),
       showStats.includes("discussions_started"),
       showStats.includes("discussions_answered"),
-      commitsYear,
+      commitsYearParsed,
       repository,
       repoOwner,
       showStats.includes("prs_authored"),
@@ -139,7 +139,7 @@ export default async (
           card_width: parseInt(card_width, 10),
           hide_rank: parseBoolean(hide_rank),
           include_all_commits: parseBoolean(include_all_commits),
-          commits_year: commitsYear,
+          commits_year: commitsYearParsed,
           line_height,
           text_bold: parseBoolean(text_bold),
           custom_title,

--- a/packages/core/src/api/index.js
+++ b/packages/core/src/api/index.js
@@ -81,6 +81,20 @@ export default async (
     };
   }
 
+  // anything but a four-digit year builds a DateTime GitHub rejects
+  if (commits_year !== undefined && !/^\d{4}$/.test(commits_year)) {
+    return {
+      status: "error - permanent",
+      content: renderError({
+        message: "Something went wrong",
+        secondaryMessage: 'Invalid number input for parameter "commits_year"',
+        renderOptions: colorParams,
+      }),
+    };
+  }
+  const commitsYear =
+    commits_year === undefined ? undefined : Number(commits_year);
+
   try {
     const showStats = parseArray(show);
     const repoOwner = parseArray(owner);
@@ -97,7 +111,7 @@ export default async (
         showStats.includes("prs_merged_percentage"),
       showStats.includes("discussions_started"),
       showStats.includes("discussions_answered"),
-      parseInt(commits_year, 10),
+      commitsYear,
       repository,
       repoOwner,
       showStats.includes("prs_authored"),
@@ -125,7 +139,7 @@ export default async (
           card_width: parseInt(card_width, 10),
           hide_rank: parseBoolean(hide_rank),
           include_all_commits: parseBoolean(include_all_commits),
-          commits_year: parseInt(commits_year, 10),
+          commits_year: commitsYear,
           line_height,
           text_bold: parseBoolean(text_bold),
           custom_title,

--- a/packages/core/src/common/date.ts
+++ b/packages/core/src/common/date.ts
@@ -1,0 +1,45 @@
+/** A span between two dates, as GitHub's range arguments take it. */
+interface GitHubDateRange {
+  /** Start of the range, inclusive. */
+  from: Date;
+  /** End of the range, inclusive. */
+  to: Date;
+}
+
+/**
+ * Format a date as a GitHub `DateTime` scalar.
+ * Seconds precision, no milliseconds.
+ *
+ * @param date Date to format.
+ * @returns e.g. `2024-01-01T00:00:00Z`.
+ */
+const toGitHubDateTime = (date: Date): string =>
+  `${date.toISOString().slice(0, 19)}Z`;
+
+/**
+ * The full UTC span of a calendar year, both ends inclusive.
+ *
+ * The end matters to callers that would otherwise leave a range open:
+ * GitHub's `contributionsCollection` defaults `to` to one year after `from`,
+ * which pulls the next 1st of January into the year.
+ *
+ * @param year Four-digit year.
+ * @returns The range covering it.
+ */
+const getGitHubYearRange = (year: number): GitHubDateRange => ({
+  from: new Date(Date.UTC(year, 0, 1)),
+  to: new Date(Date.UTC(year, 11, 31, 23, 59, 59)),
+});
+
+/**
+ * Get diff in minutes between two dates.
+ *
+ * @param d1 First date.
+ * @param d2 Second date.
+ * @returns Number of minutes between the two dates.
+ */
+const dateDiff = (d1: Date, d2: Date): number =>
+  Math.round((d1.getTime() - d2.getTime()) / (1000 * 60));
+
+export { dateDiff, getGitHubYearRange, toGitHubDateTime };
+export type { GitHubDateRange };

--- a/packages/core/src/common/ops.ts
+++ b/packages/core/src/common/ops.ts
@@ -99,20 +99,6 @@ const parseEmojis = (str: string): string => {
   });
 };
 
-/**
- * Get diff in minutes between two dates.
- *
- * @param d1 First date.
- * @param d2 Second date.
- * @returns Number of minutes between the two dates.
- */
-const dateDiff = (d1: Date, d2: Date): number => {
-  const date1 = new Date(d1);
-  const date2 = new Date(d2);
-  const diff = date1.getTime() - date2.getTime();
-  return Math.round(diff / (1000 * 60));
-};
-
 const isOwnerAffiliation = (value: string): value is RepositoryAffiliation =>
   OWNER_AFFILIATIONS.some((affiliation) => affiliation === value);
 
@@ -167,7 +153,6 @@ export {
   lowercaseTrim,
   chunkArray,
   parseEmojis,
-  dateDiff,
   parseOwnerAffiliations,
   buildSearchFilter,
 };

--- a/packages/core/src/fetchers/stats.ts
+++ b/packages/core/src/fetchers/stats.ts
@@ -4,6 +4,8 @@ import githubUsernameRegex from "github-username-regex";
 
 import { calculateRank } from "../calculateRank.js";
 import { getConfig } from "../common/config.js";
+import type { GitHubDateRange } from "../common/date.js";
+import { getGitHubYearRange, toGitHubDateTime } from "../common/date.js";
 import { CustomError, MissingParamError } from "../common/error.js";
 import { wrapTextMultiline } from "../common/fmt.js";
 import { createGraphQLFetcher } from "../common/http.js";
@@ -21,7 +23,6 @@ import type {
   UserInfoQuery,
   UserInfoQueryVariables,
 } from "../graphql/generated/stats.js";
-import type { ContributionRange } from "../graphql/reposContributedToDocument.js";
 import {
   MAX_REPOSITORIES_LIMIT,
   buildReposContributedToDocument,
@@ -355,10 +356,10 @@ const roundToNearestMidnight = (timestamp: number): number =>
 /**
  * Fetch the repositories a user contributed to across every given range.
  *
- * All ranges still pending are queried together in a single request. Whenever a
- * range's sub-collection returns `MAX_REPOSITORIES_LIMIT` results,
- * that range is split and requeried in the next round, since the true count
- * could be higher and some repos may be missing from the response.
+ * All ranges still pending are queried together in a single request.
+ * Whenever a range's sub-collection returns `MAX_REPOSITORIES_LIMIT` results,
+ * that range is split and requeried in the next round,
+ * since the true count could be higher and some repos may be missing from the response.
  *
  * @param username GitHub username.
  * @param ranges Ranges to fetch.
@@ -368,7 +369,7 @@ const roundToNearestMidnight = (timestamp: number): number =>
  */
 const fetchReposContributedTo = async (
   username: string,
-  ranges: Array<ContributionRange>,
+  ranges: Array<GitHubDateRange>,
   includeOwnRepos: boolean,
   pat: string | null,
 ): Promise<Set<string>> => {
@@ -407,7 +408,7 @@ const fetchReposContributedTo = async (
       );
     }
 
-    const nextPending: Array<ContributionRange> = [];
+    const nextPending: Array<GitHubDateRange> = [];
     pending.forEach((range, index) => {
       const rangeResponse = user[`range_${index}`];
       if (!rangeResponse) {
@@ -439,9 +440,9 @@ const fetchReposContributedTo = async (
             range.from.getTime() + Math.floor(rangeDays / 2) * MS_PER_DAY,
           ),
         );
-        // GitHub seems to use only the date portion and ignore the time. So we
-        // subtract 1 second from the `to` of the first half to wrap it to the
-        // previous day and avoid a 1-day overlap of the two halves.
+        // GitHub seems to use only the date portion and ignore the time.
+        // So we subtract 1 second from the `to` of the first half
+        // to wrap it to the previous day and avoid a 1-day overlap of the two halves.
         nextPending.push({
           from: range.from,
           to: new Date(mid.getTime() - 1000),
@@ -488,12 +489,12 @@ const fetchReposContributedTo = async (
 };
 
 /**
- * Calculates the count of repositories the user contributed to, across every
- * contribution year.
+ * Calculates the count of repositories the user contributed to,
+ * across every contribution year.
  *
- * GitHub's `repositoriesContributedTo` field can only span one year. So we walk
- * every year individually via `contributionsCollection(from, to)` and
- * de-duplicate the repo results.
+ * GitHub's `repositoriesContributedTo` field can only span one year.
+ * So we walk every year individually via `contributionsCollection(from, to)`
+ * and de-duplicate the repo results.
  *
  * Whether private contributions are included depends on the used PAT.
  *
@@ -509,10 +510,7 @@ const fetchAllTimeReposContributedTo = async (
   includeOwnRepos: boolean,
   pat: string | null = null,
 ): Promise<number> => {
-  const ranges: Array<ContributionRange> = years.map((year) => ({
-    from: new Date(Date.UTC(year, 0, 1)),
-    to: new Date(Date.UTC(year, 11, 31, 23, 59, 59)),
-  }));
+  const ranges: Array<GitHubDateRange> = years.map(getGitHubYearRange);
   const repos = await fetchReposContributedTo(
     username,
     ranges,
@@ -599,7 +597,10 @@ const fetchStats = async (
     includeMergedPullRequests: include_merged_pull_requests,
     includeDiscussions: include_discussions,
     includeDiscussionsAnswers: include_discussions_answers,
-    startTime: commits_year ? `${commits_year}-01-01T00:00:00Z` : undefined,
+    startTime:
+      commits_year === undefined
+        ? undefined
+        : toGitHubDateTime(getGitHubYearRange(commits_year).from),
     ownerAffiliations: affiliations,
     includeUserRepositories: contribs_include_own_repos,
     pat,

--- a/packages/core/src/fetchers/stats.ts
+++ b/packages/core/src/fetchers/stats.ts
@@ -11,7 +11,11 @@ import { wrapTextMultiline } from "../common/fmt.js";
 import { createGraphQLFetcher } from "../common/http.js";
 import type { GraphQLResponse } from "../common/http.js";
 import { logger } from "../common/log.js";
-import { buildSearchFilter, parseOwnerAffiliations } from "../common/ops.js";
+import {
+  buildSearchFilter,
+  chunkArray,
+  parseOwnerAffiliations,
+} from "../common/ops.js";
 import { retryer } from "../common/retryer.js";
 import { buildContributionsDocument } from "../graphql/contributionsDocument.js";
 import {
@@ -286,6 +290,25 @@ const fetchRepoUserStats = async (
 };
 
 /**
+ * Turn a GraphQL `errors` payload into the error to throw.
+ *
+ * @param errors Errors from the response envelope.
+ * @param statusText HTTP status text, used as the error type when GitHub gave a message.
+ * @param fallback Message when GitHub gave none.
+ */
+const graphqlError = (
+  errors: NonNullable<GraphQLResponse<unknown>["data"]["errors"]>,
+  statusText: string,
+  fallback: string,
+): CustomError => {
+  logger.error(errors);
+  const message = errors[0]?.message;
+  return message
+    ? new CustomError(wrapTextMultiline(message, 525, 12)[0] ?? "", statusText)
+    : new CustomError(fallback, CustomError.GRAPHQL_ERROR);
+};
+
+/**
  * Fetch all-time contributions by building a single GraphQL query
  * for all the given years.
  *
@@ -313,17 +336,10 @@ const fetchTotalContributions = async (
   );
 
   if (contribRes.data.errors) {
-    logger.error(contribRes.data.errors);
-    const firstError = contribRes.data.errors[0];
-    if (firstError?.message) {
-      throw new CustomError(
-        wrapTextMultiline(firstError.message, 525, 12)[0] ?? "",
-        contribRes.statusText,
-      );
-    }
-    throw new CustomError(
+    throw graphqlError(
+      contribRes.data.errors,
+      contribRes.statusText,
       "Something went wrong while trying to retrieve the contributions data using the GraphQL API.",
-      CustomError.GRAPHQL_ERROR,
     );
   }
 
@@ -345,178 +361,133 @@ const fetchTotalContributions = async (
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
- * Round a timestamp (e.g. `Date.getTime()`) to the nearest UTC midnight.
- *
- * @param timestamp Milliseconds since epoch.
- * @returns Milliseconds since epoch of the nearest UTC midnight.
+ * Ranges per request.
+ * Each costs roughly `4 * MAX_REPOSITORIES_LIMIT` nodes,
+ * so an unchunked round of a heavily split account would breach GitHub's 500k node ceiling
+ * and lose the ranges that had already resolved along with it.
  */
-const roundToNearestMidnight = (timestamp: number): number =>
-  Math.round(timestamp / MS_PER_DAY) * MS_PER_DAY;
+const MAX_RANGES_PER_REQUEST = 100;
+
+const REPOS_CONTRIBUTED_TO_ERROR =
+  "Something went wrong while trying to retrieve the repository contributions data using the GraphQL API.";
 
 /**
- * Fetch the repositories a user contributed to across every given range.
+ * Count the repositories a user contributed to across every contribution year.
  *
- * All ranges still pending are queried together in a single request.
- * Whenever a range's sub-collection returns `MAX_REPOSITORIES_LIMIT` results,
- * that range is split and requeried in the next round,
- * since the true count could be higher and some repos may be missing from the response.
+ * `repositoriesContributedTo` spans at most one year,
+ * so every year is fetched as an aliased `contributionsCollection(from, to)` in one request and the repos de-duplicated.
+ * A range returning `MAX_REPOSITORIES_LIMIT` results may have more,
+ * so it is halved and requeried in the next round.
  *
- * @param username GitHub username.
- * @param ranges Ranges to fetch.
- * @param includeOwnRepos Whether to include the user's own repos in the result.
+ * Whether private contributions are included depends on the used PAT.
+ *
+ * @param canonicalUsername Username as GitHub reports it; `nameWithOwner` uses its
+ *        casing, which the raw query-string username need not match.
+ * @param years Contribution years to walk.
+ * @param includeOwnRepos Whether to count the user's own repositories.
  * @param pat Optional PAT override.
- * @returns The set of `nameWithOwner` repo identifiers.
+ * @returns Count of repositories.
  */
-const fetchReposContributedTo = async (
-  username: string,
-  ranges: Array<GitHubDateRange>,
+const fetchAllTimeReposContributedTo = async (
+  canonicalUsername: string,
+  years: Array<number>,
   includeOwnRepos: boolean,
   pat: string | null,
-): Promise<Set<string>> => {
+): Promise<number> => {
   const repos = new Set<string>();
-  let pending = ranges;
+  let pending = years.map(getGitHubYearRange);
 
   while (pending.length > 0) {
-    const document = buildReposContributedToDocument(pending);
-    const fetcher = createGraphQLFetcher(document, "bearer");
-    const res = await retryer(
-      fetcher,
-      { login: username, maxRepositories: MAX_REPOSITORIES_LIMIT },
-      pat,
-    );
+    const nextPending: Array<GitHubDateRange> = [];
 
-    if (res.data.errors) {
-      logger.error(res.data.errors);
-      const firstError = res.data.errors[0];
-      if (firstError?.message) {
-        throw new CustomError(
-          wrapTextMultiline(firstError.message, 525, 12)[0] ?? "",
+    for (const chunk of chunkArray(pending, MAX_RANGES_PER_REQUEST)) {
+      const fetcher = createGraphQLFetcher(
+        buildReposContributedToDocument(chunk, includeOwnRepos),
+        "bearer",
+      );
+      const res = await retryer(
+        fetcher,
+        { login: canonicalUsername, maxRepositories: MAX_REPOSITORIES_LIMIT },
+        pat,
+      );
+      if (res.data.errors) {
+        throw graphqlError(
+          res.data.errors,
           res.statusText,
+          REPOS_CONTRIBUTED_TO_ERROR,
         );
       }
-      throw new CustomError(
-        "Something went wrong while trying to retrieve the repository contributions data using the GraphQL API.",
-        CustomError.GRAPHQL_ERROR,
-      );
-    }
-
-    const user = res.data.data.user;
-    if (!user) {
-      throw new CustomError(
-        "Something went wrong while trying to retrieve the repository contributions data using the GraphQL API.",
-        CustomError.GRAPHQL_ERROR,
-      );
-    }
-
-    const nextPending: Array<GitHubDateRange> = [];
-    pending.forEach((range, index) => {
-      const rangeResponse = user[`range_${index}`];
-      if (!rangeResponse) {
+      const user = res.data.data.user;
+      if (!user) {
         throw new CustomError(
-          "Something went wrong while trying to retrieve the repository contributions data using the GraphQL API.",
+          REPOS_CONTRIBUTED_TO_ERROR,
           CustomError.GRAPHQL_ERROR,
         );
       }
 
-      const commitRepos = rangeResponse.commitContributionsByRepository;
-      const issueRepos = rangeResponse.issueContributionsByRepository;
-      const prRepos = rangeResponse.pullRequestContributionsByRepository;
-      const createdRepoNodes =
-        rangeResponse.repositoryContributions.nodes ?? [];
+      for (const [index, range] of chunk.entries()) {
+        const rangeResponse = user[`range_${index}`];
+        if (!rangeResponse) {
+          throw new CustomError(
+            REPOS_CONTRIBUTED_TO_ERROR,
+            CustomError.GRAPHQL_ERROR,
+          );
+        }
 
-      const isSaturated =
-        commitRepos.length >= MAX_REPOSITORIES_LIMIT ||
-        issueRepos.length >= MAX_REPOSITORIES_LIMIT ||
-        prRepos.length >= MAX_REPOSITORIES_LIMIT ||
-        createdRepoNodes.length >= MAX_REPOSITORIES_LIMIT;
-
-      const rangeDays = Math.round(
-        (range.to.getTime() - range.from.getTime()) / MS_PER_DAY,
-      );
-      // a range of 1 day or less can't be split any further
-      if (isSaturated && rangeDays >= 2) {
-        const mid = new Date(
-          roundToNearestMidnight(
-            range.from.getTime() + Math.floor(rangeDays / 2) * MS_PER_DAY,
+        const lists = [
+          rangeResponse.commitContributionsByRepository,
+          rangeResponse.issueContributionsByRepository,
+          rangeResponse.pullRequestContributionsByRepository,
+          (rangeResponse.repositoryContributions?.nodes ?? []).filter(
+            (node) => node !== null,
           ),
+        ];
+        const isSaturated = lists.some(
+          (list) => list.length >= MAX_REPOSITORIES_LIMIT,
         );
-        // GitHub seems to use only the date portion and ignore the time.
-        // So we subtract 1 second from the `to` of the first half
-        // to wrap it to the previous day and avoid a 1-day overlap of the two halves.
-        nextPending.push({
-          from: range.from,
-          to: new Date(mid.getTime() - 1000),
-        });
-        nextPending.push({ from: mid, to: range.to });
-        return;
-      }
-      if (isSaturated) {
-        logger.log(
-          `Range ${range.from.toISOString()} - ${range.to.toISOString()} is saturated but cannot be split further.`,
-        );
-      }
 
-      for (const { repository } of [
-        ...commitRepos,
-        ...issueRepos,
-        ...prRepos,
-      ]) {
-        repos.add(repository.nameWithOwner);
-      }
-      for (const node of createdRepoNodes) {
-        if (node) {
-          repos.add(node.repository.nameWithOwner);
+        const rangeDays = Math.round(
+          (range.to.getTime() - range.from.getTime()) / MS_PER_DAY,
+        );
+        // a range of 1 day or less can't be split any further
+        if (isSaturated && rangeDays >= 2) {
+          // every `from` sits on UTC midnight, so the split lands on a day boundary too
+          const mid = new Date(
+            range.from.getTime() + Math.floor(rangeDays / 2) * MS_PER_DAY,
+          );
+          // GitHub only reads the date portion,
+          // so the first half ends 1 second before `mid` to keep the halves from sharing a day
+          nextPending.push(
+            { from: range.from, to: new Date(mid.getTime() - 1000) },
+            { from: mid, to: range.to },
+          );
+          continue;
+        }
+        if (isSaturated) {
+          logger.log(
+            `Range ${range.from.toISOString()} - ${range.to.toISOString()} is saturated but cannot be split further.`,
+          );
+        }
+
+        for (const { repository } of lists.flat()) {
+          const name = repository.nameWithOwner;
+          if (includeOwnRepos || !name.startsWith(`${canonicalUsername}/`)) {
+            repos.add(name);
+          }
         }
       }
-    });
+    }
 
-    if (nextPending.length > 0) {
+    // each saturated range pushes both of its halves
+    const saturatedCount = nextPending.length / 2;
+    if (saturatedCount > 0) {
       logger.log(
-        `found ${pending.length} saturated ranges, splitting and retrying...`,
+        `found ${saturatedCount} saturated ranges, splitting and retrying...`,
       );
     }
     pending = nextPending;
   }
 
-  if (!includeOwnRepos) {
-    for (const repo of repos) {
-      if (repo.startsWith(`${username}/`)) {
-        repos.delete(repo);
-      }
-    }
-  }
-  return repos;
-};
-
-/**
- * Calculates the count of repositories the user contributed to,
- * across every contribution year.
- *
- * GitHub's `repositoriesContributedTo` field can only span one year.
- * So we walk every year individually via `contributionsCollection(from, to)`
- * and de-duplicate the repo results.
- *
- * Whether private contributions are included depends on the used PAT.
- *
- * @param username GitHub username.
- * @param years Contribution years to walk.
- * @param includeOwnRepos Whether to include the user's own repositories in the count.
- * @param pat Optional PAT override.
- * @returns Count of repositories.
- */
-const fetchAllTimeReposContributedTo = async (
-  username: string,
-  years: Array<number>,
-  includeOwnRepos: boolean,
-  pat: string | null = null,
-): Promise<number> => {
-  const ranges: Array<GitHubDateRange> = years.map(getGitHubYearRange);
-  const repos = await fetchReposContributedTo(
-    username,
-    ranges,
-    includeOwnRepos,
-    pat,
-  );
   return repos.size;
 };
 
@@ -689,7 +660,7 @@ const fetchStats = async (
 
   if (include_all_time_contribs) {
     stats.allTimeContributedTo = await fetchAllTimeReposContributedTo(
-      username,
+      user.login,
       user.contributionsCollection.contributionYears,
       contribs_include_own_repos,
       pat,

--- a/packages/core/src/graphql/contributionsDocument.ts
+++ b/packages/core/src/graphql/contributionsDocument.ts
@@ -1,3 +1,5 @@
+import { getGitHubYearRange, toGitHubDateTime } from "../common/date.js";
+
 import type { YearContributionsFragment } from "./generated/stats.js";
 import { graphqlDocument } from "./graphqlDocument.js";
 
@@ -19,10 +21,8 @@ interface ContributionsQuery {
 const buildContributionsDocument = (years: Array<number>) => {
   const yearFields = years
     .map((year) => {
-      // without "to", 2024-01-01 would count toward year=2023
-      const from = `${year}-01-01T00:00:00Z`;
-      const to = `${year}-12-31T23:59:59Z`;
-      return `year_${year}: contributionsCollection(from: "${from}", to: "${to}") { ...YearContributions }`;
+      const { from, to } = getGitHubYearRange(year);
+      return `year_${year}: contributionsCollection(from: "${toGitHubDateTime(from)}", to: "${toGitHubDateTime(to)}") { ...YearContributions }`;
     })
     .join("\n");
 

--- a/packages/core/src/graphql/contributionsDocument.ts
+++ b/packages/core/src/graphql/contributionsDocument.ts
@@ -41,3 +41,4 @@ fragment YearContributions on ContributionsCollection {
 };
 
 export { buildContributionsDocument };
+export type { ContributionsQuery };

--- a/packages/core/src/graphql/generated/stats.ts
+++ b/packages/core/src/graphql/generated/stats.ts
@@ -87,7 +87,7 @@ export type RangeContributionsByRepoFragment = {
   pullRequestContributionsByRepository: Array<{
     repository: { nameWithOwner: string };
   }>;
-  repositoryContributions: {
+  repositoryContributions?: {
     nodes: Array<{ repository: { nameWithOwner: string } } | null> | null;
   };
 };

--- a/packages/core/src/graphql/queries/stats.graphql
+++ b/packages/core/src/graphql/queries/stats.graphql
@@ -109,7 +109,8 @@ fragment RangeContributionsByRepo on ContributionsCollection {
       nameWithOwner
     }
   }
-  repositoryContributions(first: $maxRepositories) {
+  repositoryContributions(first: $maxRepositories)
+    @include(if: $includeOwnRepos) {
     nodes {
       repository {
         nameWithOwner

--- a/packages/core/src/graphql/reposContributedToDocument.ts
+++ b/packages/core/src/graphql/reposContributedToDocument.ts
@@ -25,15 +25,33 @@ interface ReposContributedToQuery {
  * filter used by `repositoriesContributedTo` in `stats.graphql`.
  *
  * @param ranges Ranges to fetch, one `range_<index>` alias each.
+ * @param includeOwnRepos Whether to select `repositoryContributions`.
  * @returns Document for `createGraphQLFetcher`.
  */
-const buildReposContributedToDocument = (ranges: Array<GitHubDateRange>) => {
+const buildReposContributedToDocument = (
+  ranges: Array<GitHubDateRange>,
+  includeOwnRepos: boolean,
+) => {
   const rangeFields = ranges
     .map(
       ({ from, to }, index) =>
         `range_${index}: contributionsCollection(from: "${toGitHubDateTime(from)}", to: "${toGitHubDateTime(to)}") { ...RangeContributionsByRepo }`,
     )
     .join("\n");
+
+  // `repositoryContributions` only ever returns repos the user owns, so it is left
+  // out rather than gated with @include: an excluded field still counts toward the
+  // query's node cost. stats.graphql carries the directive so the generated type
+  // marks the field optional.
+  const ownRepoField = includeOwnRepos
+    ? `repositoryContributions(first: $maxRepositories) {
+    nodes {
+      repository {
+        nameWithOwner
+      }
+    }
+  }`
+    : "";
 
   // fragment must match queries/stats.graphql, which generates its type
   return graphqlDocument<
@@ -61,13 +79,7 @@ fragment RangeContributionsByRepo on ContributionsCollection {
       nameWithOwner
     }
   }
-  repositoryContributions(first: $maxRepositories) {
-    nodes {
-      repository {
-        nameWithOwner
-      }
-    }
-  }
+  ${ownRepoField}
 }`);
 };
 

--- a/packages/core/src/graphql/reposContributedToDocument.ts
+++ b/packages/core/src/graphql/reposContributedToDocument.ts
@@ -1,3 +1,6 @@
+import type { GitHubDateRange } from "../common/date.js";
+import { toGitHubDateTime } from "../common/date.js";
+
 import type { RangeContributionsByRepoFragment } from "./generated/stats.js";
 import { graphqlDocument } from "./graphqlDocument.js";
 
@@ -13,12 +16,6 @@ interface ReposContributedToQuery {
   user: Record<`range_${number}`, RangeContributionsByRepoFragment> | null;
 }
 
-/** A date range to query for contributions. */
-interface ContributionRange {
-  from: Date;
-  to: Date;
-}
-
 /**
  * Build a query for the repositories a user contributed to within multiple time
  * ranges. One aliased `contributionsCollection` field per range, so all ranges
@@ -30,11 +27,11 @@ interface ContributionRange {
  * @param ranges Ranges to fetch, one `range_<index>` alias each.
  * @returns Document for `createGraphQLFetcher`.
  */
-const buildReposContributedToDocument = (ranges: Array<ContributionRange>) => {
+const buildReposContributedToDocument = (ranges: Array<GitHubDateRange>) => {
   const rangeFields = ranges
     .map(
       ({ from, to }, index) =>
-        `range_${index}: contributionsCollection(from: "${from.toISOString()}", to: "${to.toISOString()}") { ...RangeContributionsByRepo }`,
+        `range_${index}: contributionsCollection(from: "${toGitHubDateTime(from)}", to: "${toGitHubDateTime(to)}") { ...RangeContributionsByRepo }`,
     )
     .join("\n");
 
@@ -75,4 +72,3 @@ fragment RangeContributionsByRepo on ContributionsCollection {
 };
 
 export { buildReposContributedToDocument, MAX_REPOSITORIES_LIMIT };
-export type { ContributionRange };

--- a/packages/core/src/graphql/reposContributedToDocument.ts
+++ b/packages/core/src/graphql/reposContributedToDocument.ts
@@ -39,10 +39,9 @@ const buildReposContributedToDocument = (
     )
     .join("\n");
 
-  // `repositoryContributions` only ever returns repos the user owns, so it is left
-  // out rather than gated with @include: an excluded field still counts toward the
-  // query's node cost. stats.graphql carries the directive so the generated type
-  // marks the field optional.
+  // `repositoryContributions` only ever returns repos the user owns,
+  // so it is left out rather than gated with @include: an excluded field still counts toward the query's node cost.
+  // stats.graphql carries the directive so the generated type marks the field optional.
   const ownRepoField = includeOwnRepos
     ? `repositoryContributions(first: $maxRepositories) {
     nodes {
@@ -84,3 +83,4 @@ fragment RangeContributionsByRepo on ContributionsCollection {
 };
 
 export { buildReposContributedToDocument, MAX_REPOSITORIES_LIMIT };
+export type { ReposContributedToQuery };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,8 @@ export { retryer } from "./common/retryer.js";
 
 export { renderError } from "./common/render.js";
 
-export { dateDiff, clampValue } from "./common/ops.js";
+export { clampValue } from "./common/ops.js";
+export { dateDiff } from "./common/date.js";
 
 export { logger } from "./common/log.js";
 export { request } from "./common/http.js";

--- a/packages/core/tests/apiInputValidation.test.js
+++ b/packages/core/tests/apiInputValidation.test.js
@@ -27,4 +27,23 @@ describe("API input validation", () => {
       expect(result.content).toContain("unsafe characters");
     });
   });
+
+  describe("stats: commits_year", () => {
+    // "" and "12" used to parse to NaN and be silently ignored; "1" reached
+    // GitHub as an unparsable DateTime and surfaced as a temporary error.
+    it.each(["", "abc", "1", "12", "20244", "2024.5", "-2024"])(
+      "rejects %j",
+      async (value) => {
+        const result = await statsApi({
+          username: "user",
+          commits_year: value,
+        });
+        expect(result.status).toBe("error - permanent");
+        // the error card html-escapes the quotes around the parameter name
+        expect(result.content).toContain(
+          "Invalid number input for parameter &#34;commits_year&#34;",
+        );
+      },
+    );
+  });
 });

--- a/packages/core/tests/date.test.ts
+++ b/packages/core/tests/date.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dateDiff,
+  getGitHubYearRange,
+  toGitHubDateTime,
+} from "../src/common/date.js";
+
+describe("Test date.js", () => {
+  it("should test dateDiff", () => {
+    const a = new Date("2020-01-01T00:10:00Z");
+    const b = new Date("2020-01-01T00:00:00Z");
+    expect(dateDiff(a, b)).toBe(10);
+
+    const c = new Date("2020-01-01T00:00:00Z");
+    const d = new Date("2020-01-01T00:10:30Z");
+    // rounds to nearest minute
+    expect(dateDiff(c, d)).toBe(-10);
+  });
+
+  it("should test toGitHubDateTime", () => {
+    expect(toGitHubDateTime(new Date(Date.UTC(2024, 0, 1)))).toBe(
+      "2024-01-01T00:00:00Z",
+    );
+    // milliseconds are dropped, not rounded
+    expect(toGitHubDateTime(new Date("2024-06-15T10:20:30.999Z"))).toBe(
+      "2024-06-15T10:20:30Z",
+    );
+  });
+
+  it("should test getGitHubYearRange", () => {
+    const { from, to } = getGitHubYearRange(2024);
+    expect(toGitHubDateTime(from)).toBe("2024-01-01T00:00:00Z");
+    expect(toGitHubDateTime(to)).toBe("2024-12-31T23:59:59Z");
+  });
+
+  it("should cover a leap day", () => {
+    const { from, to } = getGitHubYearRange(2024);
+    const days = (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000);
+    expect(Math.ceil(days)).toBe(366);
+  });
+});

--- a/packages/core/tests/fetchStats.test.ts
+++ b/packages/core/tests/fetchStats.test.ts
@@ -4,93 +4,128 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { calculateRank } from "../src/calculateRank.js";
 import { loadConfigFromEnv } from "../src/common/config.js";
+import type { GraphQLResponse } from "../src/common/http.js";
 import { fetchStats } from "../src/fetchers/stats.js";
+import type { StatsData } from "../src/fetchers/types.js";
+import type { ContributionsQuery } from "../src/graphql/contributionsDocument.js";
+import type {
+  RangeContributionsByRepoFragment,
+  RepoStarsFragment,
+  UserInfoQuery,
+  UserReposQuery,
+} from "../src/graphql/generated/stats.js";
+import type { ReposContributedToQuery } from "../src/graphql/reposContributedToDocument.js";
 
 vi.mock(import("../src/common/log.js"), async () => {
   const { createLoggerMock } = await import("./utils.js");
   return createLoggerMock();
 });
 
+/** Body of a GraphQL response, as the mocked endpoint returns it. */
+type GraphQLBody<TResult> = GraphQLResponse<TResult>["data"];
+/** A query's `user`, when the lookup succeeded. */
+type QueryUser<TResult extends { user: unknown }> = NonNullable<
+  TResult["user"]
+>;
+
 // Test parameters.
-const data_stats = {
-  data: {
-    user: {
-      name: "Anurag Hazra",
-      login: "anuraghazra",
-      repositoriesContributedTo: { totalCount: 61 },
-      contributionsCollection: {
-        contributionYears: [2022, 2024],
-      },
-      commits: {
-        totalCommitContributions: 100,
-      },
-      reviews: {
-        totalPullRequestReviewContributions: 50,
-      },
-      pullRequests: { totalCount: 300 },
-      mergedPullRequests: { totalCount: 240 },
-      openIssues: { totalCount: 100 },
-      closedIssues: { totalCount: 100 },
-      followers: { totalCount: 100 },
-      repositoryDiscussions: { totalCount: 10 },
-      repositoryDiscussionComments: { totalCount: 40 },
-      repositories: {
-        totalCount: 3,
-        nodes: [
-          { name: "test-repo-1", stargazerCount: 100 },
-          { name: "test-repo-2", stargazerCount: 100 },
-          { name: "test-repo-3", stargazerCount: 100 },
-        ],
-        pageInfo: {
-          hasNextPage: true,
-          endCursor: "cursor",
-        },
-      },
+const user_stats: QueryUser<UserInfoQuery> = {
+  name: "Anurag Hazra",
+  login: "anuraghazra",
+  repositoriesContributedTo: { totalCount: 61 },
+  contributionsCollection: {
+    contributionYears: [2022, 2024],
+  },
+  commits: {
+    totalCommitContributions: 100,
+  },
+  reviews: {
+    totalPullRequestReviewContributions: 50,
+  },
+  pullRequests: { totalCount: 300 },
+  mergedPullRequests: { totalCount: 240 },
+  openIssues: { totalCount: 100 },
+  closedIssues: { totalCount: 100 },
+  followers: { totalCount: 100 },
+  repositoryDiscussions: { totalCount: 10 },
+  repositoryDiscussionComments: { totalCount: 40 },
+  repositories: {
+    totalCount: 3,
+    nodes: [
+      { name: "test-repo-1", stargazerCount: 100 },
+      { name: "test-repo-2", stargazerCount: 100 },
+      { name: "test-repo-3", stargazerCount: 100 },
+    ],
+    pageInfo: {
+      hasNextPage: true,
+      endCursor: "cursor",
     },
   },
 };
 
-const data_year2003 = structuredClone(data_stats);
-data_year2003.data.user.commits.totalCommitContributions = 428;
+const data_stats: GraphQLBody<UserInfoQuery> = { data: { user: user_stats } };
 
-const data_stats_with_own_repos = structuredClone(data_stats);
-data_stats_with_own_repos.data.user.repositoriesContributedTo.totalCount = 75;
+const data_year2003: GraphQLBody<UserInfoQuery> = {
+  data: {
+    user: { ...user_stats, commits: { totalCommitContributions: 428 } },
+  },
+};
 
-const data_without_pull_requests = {
+const data_stats_with_own_repos: GraphQLBody<UserInfoQuery> = {
+  data: {
+    user: { ...user_stats, repositoriesContributedTo: { totalCount: 75 } },
+  },
+};
+
+const data_without_pull_requests: GraphQLBody<UserInfoQuery> = {
   data: {
     user: {
-      ...data_stats.data.user,
+      ...user_stats,
       pullRequests: { totalCount: 0 },
       mergedPullRequests: { totalCount: 0 },
     },
   },
 };
 
-const data_repo = {
+const repo_page: RepoStarsFragment["repositories"] = {
+  totalCount: 2,
+  nodes: [
+    { name: "test-repo-4", stargazerCount: 50 },
+    { name: "test-repo-5", stargazerCount: 50 },
+  ],
+  pageInfo: {
+    hasNextPage: false,
+    endCursor: "cursor",
+  },
+};
+
+const data_repo: GraphQLBody<UserReposQuery> = {
+  data: { user: { repositories: repo_page } },
+};
+
+// cursors distinct from data_stats' so the chaining assertion can see advancement
+const data_repo_page2: GraphQLBody<UserReposQuery> = {
   data: {
     user: {
       repositories: {
-        nodes: [
-          { name: "test-repo-4", stargazerCount: 50 },
-          { name: "test-repo-5", stargazerCount: 50 },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          endCursor: "cursor",
-        },
+        ...repo_page,
+        pageInfo: { hasNextPage: true, endCursor: "cursor-2" },
+      },
+    },
+  },
+};
+const data_repo_page3: GraphQLBody<UserReposQuery> = {
+  data: {
+    user: {
+      repositories: {
+        ...repo_page,
+        pageInfo: { hasNextPage: true, endCursor: "cursor-3" },
       },
     },
   },
 };
 
-const data_repo_page2 = structuredClone(data_repo);
-data_repo_page2.data.user.repositories.pageInfo.hasNextPage = true;
-// distinct from data_stats' cursor so the chaining assertion can see advancement
-data_repo_page2.data.user.repositories.pageInfo.endCursor = "cursor-2";
-const data_repo_page3 = structuredClone(data_repo_page2);
-data_repo_page3.data.user.repositories.pageInfo.endCursor = "cursor-3";
-
-const data_repo_zero_stars = {
+const data_repo_zero_stars: GraphQLBody<UserReposQuery> = {
   data: {
     user: {
       repositories: {
@@ -111,7 +146,7 @@ const data_repo_zero_stars = {
   },
 };
 
-const data_contributions = {
+const data_contributions: GraphQLBody<ContributionsQuery> = {
   data: {
     user: {
       year_2022: { contributionCalendar: { totalContributions: 150 } },
@@ -120,9 +155,10 @@ const data_contributions = {
   },
 };
 
-// `repositoryContributions` only ever returns repos the user owns, so every entry
-// under it is `anuraghazra/*`. It repeats across ranges to exercise de-duplication.
-const data_repos_contributed_to = {
+// `repositoryContributions` only ever returns repos the user owns,
+// so every entry under it is `anuraghazra/*`.
+// It repeats across ranges to exercise de-duplication.
+const data_repos_contributed_to: GraphQLBody<ReposContributedToQuery> = {
   data: {
     user: {
       range_0: {
@@ -157,18 +193,99 @@ const data_repos_contributed_to = {
   },
 };
 
-const error = {
+const error: GraphQLBody<UserInfoQuery> = {
+  data: { user: null },
   errors: [
     {
       type: "NOT_FOUND",
-      path: ["user"],
-      locations: [],
       message: "Could not resolve to a User with the login of 'noname'.",
     },
   ],
 };
 
 const mock = new MockAdapter(axios);
+
+/** `fetchStats` for the mocked user, with only the options a test changes spelled out. */
+const fetchStatsWith = ({
+  include_all_commits = false,
+  exclude_repo = [],
+  include_merged_pull_requests = false,
+  include_discussions = false,
+  include_discussions_answers = false,
+  commits_year,
+  include_contributions = false,
+  include_all_time_contribs = false,
+  contribs_include_own_repos = false,
+}: {
+  include_all_commits?: boolean;
+  exclude_repo?: Array<string>;
+  include_merged_pull_requests?: boolean;
+  include_discussions?: boolean;
+  include_discussions_answers?: boolean;
+  commits_year?: number;
+  include_contributions?: boolean;
+  include_all_time_contribs?: boolean;
+  contribs_include_own_repos?: boolean;
+}) =>
+  fetchStats(
+    "anuraghazra",
+    include_all_commits,
+    exclude_repo,
+    include_merged_pull_requests,
+    include_discussions,
+    include_discussions_answers,
+    commits_year,
+    [],
+    [],
+    false,
+    false,
+    false,
+    false,
+    false,
+    [],
+    include_contributions,
+    include_all_time_contribs,
+    contribs_include_own_repos,
+  );
+
+type RankInput = Parameters<typeof calculateRank>[0];
+
+/** The stats `data_stats` yields, with overrides for the fields and rank inputs a test changes. */
+const expectedStats = (
+  overrides: Partial<StatsData> = {},
+  rankOverrides: Partial<RankInput> = {},
+): StatsData => ({
+  contributedTo: 61,
+  allTimeContributedTo: 0,
+  name: "Anurag Hazra",
+  totalCommits: 100,
+  totalIssues: 200,
+  totalPRs: 300,
+  totalPRsMerged: 0,
+  mergedPRsPercentage: 0,
+  totalReviews: 50,
+  totalStars: 300,
+  totalDiscussionsStarted: 0,
+  totalDiscussionsAnswered: 0,
+  totalPRsAuthored: 0,
+  totalPRsCommented: 0,
+  totalPRsReviewed: 0,
+  totalIssuesAuthored: 0,
+  totalIssuesCommented: 0,
+  totalContributions: 0,
+  rank: calculateRank({
+    all_commits: false,
+    commits: 100,
+    prs: 300,
+    reviews: 50,
+    issues: 200,
+    repos: 5,
+    stars: 300,
+    followers: 100,
+    ...rankOverrides,
+  }),
+  ...overrides,
+});
 
 beforeEach(() => {
   vi.stubEnv("FETCH_MULTI_PAGE_STARS", "false"); // Set to `false` to fetch only one page of stars.
@@ -208,38 +325,7 @@ afterEach(() => {
 describe("Test fetchStats", () => {
   it("should fetch correct stats", async () => {
     const stats = await fetchStats("anuraghazra");
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(expectedStats());
   });
 
   it("should stop fetching when there are repos with zero stars", async () => {
@@ -251,38 +337,7 @@ describe("Test fetchStats", () => {
       .replyOnce(200, data_repo_zero_stars);
 
     const stats = await fetchStats("anuraghazra");
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(expectedStats());
   });
 
   it("should throw error", async () => {
@@ -301,39 +356,13 @@ describe("Test fetchStats", () => {
       )
       .reply(200, { total_count: 1000 });
 
-    const stats = await fetchStats("anuraghazra", true);
-    const rank = calculateRank({
-      all_commits: true,
-      commits: 1000,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 1000,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    const stats = await fetchStatsWith({ include_all_commits: true });
+    expect(stats).toStrictEqual(
+      expectedStats(
+        { totalCommits: 1000 },
+        { all_commits: true, commits: 1000 },
+      ),
+    );
   });
 
   it("should throw specific error when include_all_commits true and invalid username", async () => {
@@ -349,7 +378,7 @@ describe("Test fetchStats", () => {
       )
       .reply(200, { error: "Some test error message" });
 
-    await expect(fetchStats("anuraghazra", true)).rejects.toThrow(
+    await expect(fetchStatsWith({ include_all_commits: true })).rejects.toThrow(
       "Could not fetch data from GitHub REST API.",
     );
   });
@@ -361,39 +390,16 @@ describe("Test fetchStats", () => {
       )
       .reply(200, { total_count: 1000 });
 
-    const stats = await fetchStats("anuraghazra", true, ["test-repo-1"]);
-    const rank = calculateRank({
-      all_commits: true,
-      commits: 1000,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 200,
-      followers: 100,
+    const stats = await fetchStatsWith({
+      include_all_commits: true,
+      exclude_repo: ["test-repo-1"],
     });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 1000,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 200,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(
+      expectedStats(
+        { totalCommits: 1000, totalStars: 200 },
+        { all_commits: true, commits: 1000, stars: 200 },
+      ),
+    );
   });
 
   it("should fetch two pages of stars if 'FETCH_MULTI_PAGE_STARS' env variable is set to `true`", async () => {
@@ -401,38 +407,9 @@ describe("Test fetchStats", () => {
     loadConfigFromEnv();
 
     const stats = await fetchStats("anuraghazra");
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 400,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 400,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(
+      expectedStats({ totalStars: 400 }, { stars: 400 }),
+    );
   });
 
   it("should fetch one page of stars if 'FETCH_MULTI_PAGE_STARS' env variable is set to `false`", async () => {
@@ -440,38 +417,7 @@ describe("Test fetchStats", () => {
     loadConfigFromEnv();
 
     const stats = await fetchStats("anuraghazra");
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(expectedStats());
   });
 
   it("should fetch one page of stars if 'FETCH_MULTI_PAGE_STARS' env variable is not set", async () => {
@@ -479,38 +425,7 @@ describe("Test fetchStats", () => {
     loadConfigFromEnv();
 
     const stats = await fetchStats("anuraghazra");
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(expectedStats());
   });
 
   it("should fetch at most 'FETCH_MULTI_PAGE_STARS' pages when it is a number", async () => {
@@ -560,140 +475,35 @@ describe("Test fetchStats", () => {
 
   it("should not fetch additional stats data when it not requested", async () => {
     const stats = await fetchStats("anuraghazra");
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(expectedStats());
   });
 
   it("should fetch additional stats when it requested", async () => {
-    const stats = await fetchStats("anuraghazra", false, [], true, true, true);
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
+    const stats = await fetchStatsWith({
+      include_merged_pull_requests: true,
+      include_discussions: true,
+      include_discussions_answers: true,
     });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 240,
-      mergedPRsPercentage: 80,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 10,
-      totalDiscussionsAnswered: 40,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalContributions: 0,
-      rank,
-    });
+    expect(stats).toStrictEqual(
+      expectedStats({
+        totalPRsMerged: 240,
+        mergedPRsPercentage: 80,
+        totalDiscussionsStarted: 10,
+        totalDiscussionsAnswered: 40,
+      }),
+    );
   });
 
   it("should get commits of provided year", async () => {
-    const stats = await fetchStats(
-      "anuraghazra",
-      false,
-      [],
-      false,
-      false,
-      false,
-      2003,
+    const stats = await fetchStatsWith({ commits_year: 2003 });
+
+    expect(stats).toStrictEqual(
+      expectedStats({ totalCommits: 428 }, { commits: 428 }),
     );
-
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 428,
-      prs: 300,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 428,
-      totalIssues: 200,
-      totalPRs: 300,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalContributions: 0,
-      rank,
-    });
   });
 
   it("should fetch total contributions when include_contributions is true", async () => {
-    const stats = await fetchStats(
-      "anuraghazra",
-      false,
-      [],
-      false,
-      false,
-      false,
-      undefined,
-      [],
-      [],
-      false,
-      false,
-      false,
-      false,
-      false,
-      [],
-      true, // include_contributions
-    );
+    const stats = await fetchStatsWith({ include_contributions: true });
 
     expect(stats.totalContributions).toBe(350);
   });
@@ -717,24 +527,7 @@ describe("Test fetchStats", () => {
     });
 
     await expect(
-      fetchStats(
-        "anuraghazra",
-        false,
-        [],
-        false,
-        false,
-        false,
-        undefined,
-        [],
-        [],
-        false,
-        false,
-        false,
-        false,
-        false,
-        [],
-        true, // include_contributions
-      ),
+      fetchStatsWith({ include_contributions: true }),
     ).rejects.toThrow("Some test GraphQL error");
   });
 
@@ -751,24 +544,7 @@ describe("Test fetchStats", () => {
     });
 
     await expect(
-      fetchStats(
-        "anuraghazra",
-        false,
-        [],
-        false,
-        false,
-        false,
-        undefined,
-        [],
-        [],
-        false,
-        false,
-        false,
-        false,
-        false,
-        [],
-        true, // include_contributions
-      ),
+      fetchStatsWith({ include_contributions: true }),
     ).rejects.toThrow(
       "Something went wrong while trying to retrieve the contributions data using the GraphQL API.",
     );
@@ -778,115 +554,32 @@ describe("Test fetchStats", () => {
     mock
       .onPost("https://api.github.com/graphql")
       .reply(200, data_without_pull_requests);
-    const stats = await fetchStats("anuraghazra", false, [], true);
-    const rank = calculateRank({
-      all_commits: false,
-      commits: 100,
-      prs: 0,
-      reviews: 50,
-      issues: 200,
-      repos: 5,
-      stars: 300,
-      followers: 100,
-    });
-
-    expect(stats).toStrictEqual({
-      contributedTo: 61,
-      allTimeContributedTo: 0,
-      name: "Anurag Hazra",
-      totalCommits: 100,
-      totalIssues: 200,
-      totalPRs: 0,
-      totalPRsMerged: 0,
-      mergedPRsPercentage: 0,
-      totalReviews: 50,
-      totalStars: 300,
-      totalDiscussionsStarted: 0,
-      totalDiscussionsAnswered: 0,
-      totalIssuesAuthored: 0,
-      totalIssuesCommented: 0,
-      totalPRsAuthored: 0,
-      totalPRsCommented: 0,
-      totalPRsReviewed: 0,
-      totalContributions: 0,
-      rank,
-    });
+    const stats = await fetchStatsWith({ include_merged_pull_requests: true });
+    expect(stats).toStrictEqual(expectedStats({ totalPRs: 0 }, { prs: 0 }));
   });
 
   it("should include own repos in contributed-to count when contribs_include_own_repos is true", async () => {
     const statsWithout = await fetchStats("anuraghazra");
     expect(statsWithout.contributedTo).toBe(61);
 
-    const statsWith = await fetchStats(
-      "anuraghazra",
-      false,
-      [],
-      false,
-      false,
-      false,
-      undefined,
-      [],
-      [],
-      false,
-      false,
-      false,
-      false,
-      false,
-      [],
-      false,
-      false,
-      true, // contribs_include_own_repos
-    );
+    const statsWith = await fetchStatsWith({
+      contribs_include_own_repos: true,
+    });
     expect(statsWith.contributedTo).toBe(75);
   });
 
   it("should fetch all-time repos contributed to when include_all_time_contribs is true", async () => {
-    const stats = await fetchStats(
-      "anuraghazra",
-      false,
-      [],
-      false,
-      false,
-      false,
-      undefined,
-      [],
-      [],
-      false,
-      false,
-      false,
-      false,
-      false,
-      [],
-      false,
-      true, // include_all_time_contribs
-      false, // contribs_include_own_repos
-    );
+    const stats = await fetchStatsWith({ include_all_time_contribs: true });
 
     // org/repo1, org/repo2 and org/repo4; both anuraghazra/* repos are filtered out
     expect(stats.allTimeContributedTo).toBe(3);
   });
 
   it("should include own repos in all-time contributed-to count when contribs_include_own_repos is true", async () => {
-    const stats = await fetchStats(
-      "anuraghazra",
-      false,
-      [],
-      false,
-      false,
-      false,
-      undefined,
-      [],
-      [],
-      false,
-      false,
-      false,
-      false,
-      false,
-      [],
-      false,
-      true, // include_all_time_contribs
-      true, // contribs_include_own_repos
-    );
+    const stats = await fetchStatsWith({
+      include_all_time_contribs: true,
+      contribs_include_own_repos: true,
+    });
 
     expect(stats.allTimeContributedTo).toBe(5);
   });
@@ -909,26 +602,10 @@ describe("Test fetchStats", () => {
         return [200, data_stats];
       });
 
-      await fetchStats(
-        "anuraghazra",
-        false,
-        [],
-        false,
-        false,
-        false,
-        undefined,
-        [],
-        [],
-        false,
-        false,
-        false,
-        false,
-        false,
-        [],
-        false,
-        true, // include_all_time_contribs
-        contribsIncludeOwnRepos,
-      );
+      await fetchStatsWith({
+        include_all_time_contribs: true,
+        contribs_include_own_repos: contribsIncludeOwnRepos,
+      });
 
       // an @include(if: false) field would still count toward the node cost
       expect(contributedToQuery.includes("repositoryContributions")).toBe(
@@ -938,7 +615,7 @@ describe("Test fetchStats", () => {
   );
 
   it("should split saturated ranges until 1-day", async () => {
-    const saturatedRange = {
+    const saturatedRange: RangeContributionsByRepoFragment = {
       commitContributionsByRepository: Array.from({ length: 100 }, (_, i) => ({
         repository: { nameWithOwner: `org/repo${i}` },
       })),
@@ -956,7 +633,7 @@ describe("Test fetchStats", () => {
 
       if (req.query.includes("userReposContributedTo")) {
         const rangeCount = (req.query.match(/range_\d+:/g) ?? []).length;
-        const ranges: Record<string, unknown> = {};
+        const ranges: QueryUser<ReposContributedToQuery> = {};
         for (let i = 0; i < rangeCount; i++) {
           ranges[`range_${i}`] = saturatedRange;
         }
@@ -965,26 +642,7 @@ describe("Test fetchStats", () => {
       return [200, data_stats];
     });
 
-    const stats = await fetchStats(
-      "anuraghazra",
-      false,
-      [],
-      false,
-      false,
-      false,
-      undefined,
-      [],
-      [],
-      false,
-      false,
-      false,
-      false,
-      false,
-      [],
-      false,
-      true, // include_all_time_contribs
-      false,
-    );
+    const stats = await fetchStatsWith({ include_all_time_contribs: true });
 
     expect(stats.allTimeContributedTo).toBe(100);
     // rounds past MAX_RANGES_PER_REQUEST ranges take more than one request each

--- a/packages/core/tests/fetchStats.test.ts
+++ b/packages/core/tests/fetchStats.test.ts
@@ -16,6 +16,7 @@ const data_stats = {
   data: {
     user: {
       name: "Anurag Hazra",
+      login: "anuraghazra",
       repositoriesContributedTo: { totalCount: 61 },
       contributionsCollection: {
         contributionYears: [2022, 2024],
@@ -119,6 +120,8 @@ const data_contributions = {
   },
 };
 
+// `repositoryContributions` only ever returns repos the user owns, so every entry
+// under it is `anuraghazra/*`. It repeats across ranges to exercise de-duplication.
 const data_repos_contributed_to = {
   data: {
     user: {
@@ -131,7 +134,9 @@ const data_repos_contributed_to = {
         ],
         pullRequestContributionsByRepository: [],
         repositoryContributions: {
-          nodes: [{ repository: { nameWithOwner: "org/repo3" } }],
+          nodes: [
+            { repository: { nameWithOwner: "anuraghazra/created-repo" } },
+          ],
         },
       },
       range_1: {
@@ -143,7 +148,9 @@ const data_repos_contributed_to = {
           { repository: { nameWithOwner: "org/repo4" } },
         ],
         repositoryContributions: {
-          nodes: [{ repository: { nameWithOwner: "org/repo2" } }],
+          nodes: [
+            { repository: { nameWithOwner: "anuraghazra/created-repo" } },
+          ],
         },
       },
     },
@@ -855,7 +862,8 @@ describe("Test fetchStats", () => {
       false, // contribs_include_own_repos
     );
 
-    expect(stats.allTimeContributedTo).toBe(4);
+    // org/repo1, org/repo2 and org/repo4; both anuraghazra/* repos are filtered out
+    expect(stats.allTimeContributedTo).toBe(3);
   });
 
   it("should include own repos in all-time contributed-to count when contribs_include_own_repos is true", async () => {
@@ -882,6 +890,52 @@ describe("Test fetchStats", () => {
 
     expect(stats.allTimeContributedTo).toBe(5);
   });
+
+  it.each([
+    { contribsIncludeOwnRepos: false, shouldSelect: false },
+    { contribsIncludeOwnRepos: true, shouldSelect: true },
+  ])(
+    "should select repositoryContributions only when own repos are wanted (own repos: $contribsIncludeOwnRepos)",
+    async ({ contribsIncludeOwnRepos, shouldSelect }) => {
+      let contributedToQuery = "";
+
+      mock.reset();
+      mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+        const req = JSON.parse(cfg.data as string) as { query: string };
+        if (req.query.includes("userReposContributedTo")) {
+          contributedToQuery = req.query;
+          return [200, data_repos_contributed_to];
+        }
+        return [200, data_stats];
+      });
+
+      await fetchStats(
+        "anuraghazra",
+        false,
+        [],
+        false,
+        false,
+        false,
+        undefined,
+        [],
+        [],
+        false,
+        false,
+        false,
+        false,
+        false,
+        [],
+        false,
+        true, // include_all_time_contribs
+        contribsIncludeOwnRepos,
+      );
+
+      // an @include(if: false) field would still count toward the node cost
+      expect(contributedToQuery.includes("repositoryContributions")).toBe(
+        shouldSelect,
+      );
+    },
+  );
 
   it("should split saturated ranges until 1-day", async () => {
     const saturatedRange = {
@@ -933,6 +987,7 @@ describe("Test fetchStats", () => {
     );
 
     expect(stats.allTimeContributedTo).toBe(100);
-    expect(requestCount).toEqual(11);
+    // rounds past MAX_RANGES_PER_REQUEST ranges take more than one request each
+    expect(requestCount).toEqual(23);
   });
 });

--- a/packages/core/tests/ops.test.ts
+++ b/packages/core/tests/ops.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   chunkArray,
   clampValue,
-  dateDiff,
   lowercaseTrim,
   parseArray,
   parseBoolean,
@@ -73,16 +72,5 @@ describe("Test ops.js", () => {
     expect(() => parseEmojis("")).toThrow(/parseEmoji/);
     // @ts-expect-error testing missing argument
     expect(() => parseEmojis()).toThrow(/parseEmoji/);
-  });
-
-  it("should test dateDiff", () => {
-    const a = new Date("2020-01-01T00:10:00Z");
-    const b = new Date("2020-01-01T00:00:00Z");
-    expect(dateDiff(a, b)).toBe(10);
-
-    const c = new Date("2020-01-01T00:00:00Z");
-    const d = new Date("2020-01-01T00:10:30Z");
-    // rounds to nearest minute
-    expect(dateDiff(c, d)).toBe(-10);
   });
 });

--- a/packages/core/tests/renderStatsCard.test.ts
+++ b/packages/core/tests/renderStatsCard.test.ts
@@ -138,7 +138,6 @@ describe("Test renderStatsCard", () => {
     });
 
     expect(screen.getByTestId("all_time_contribs")).toHaveTextContent("500");
-    expect(screen.queryByTestId("all_time_contribs")).toBeInTheDocument();
   });
 
   it("should hide_rank", () => {


### PR DESCRIPTION
- Refinements for  #528 

---

- New `common/date.ts`, exposes
  - `getGitHubYearRange`
  - `toGitHubDateTime`
  - `dateDiff` (moved from `ops.ts`);
    the three places that built a year's UTC bounds now share it.
- `?commits_year` must be a four-digit year,
  rejected at the api boundary as `error - permanent` instead of `NaN` or a temporary error later.
- All-time contributed-to fetcher: filters own repos by `user.login`,
  selects `repositoryContributions` only when own repos are requested (saves nodes),
  and caps each request at `MAX_RANGES_PER_REQUEST` aliases.
- Simplified that fetcher into one function with a shared `graphqlError` helper;
  own repos are skipped while collecting and the no-op `roundToNearestMidnight` is gone.
- `fetchStats.test.ts`: fixtures are typed against the generated query types,
  and `fetchStatsWith` / `expectedStats` helpers replace the positional calls and repeated expectation blocks.