### PR TITLE
shrink links around cards

### DIFF
--- a/apps/frontend/src/styles/starlight-theme.css
+++ b/apps/frontend/src/styles/starlight-theme.css
@@ -19,6 +19,11 @@
   --sl-color-bg-sidebar: #0d1117;
 }
 
+/* Prose styles render images as blocks; shrink-wrap any link that wraps one. */
+a:has(> img) {
+  display: inline-block;
+}
+
 /* Prose styles render images as blocks, so the row is explicit. */
 .card-row {
   display: flex;


### PR DESCRIPTION
In our starlight docs, links around cards extend to the blank area to the right of the card. This small PR fixes that.