### PR TITLE
shrink links around cards refinements

### DIFF
--- a/apps/frontend/e2e/docs-card-previews.spec.ts
+++ b/apps/frontend/e2e/docs-card-previews.spec.ts
@@ -45,23 +45,19 @@ test("a preview links to itself, unless the markdown links it elsewhere", async 
 
   // Opening a preview shows its query string, so each copy links to its own theme.
   await expect(
-    page.locator(
-      'main a.card-preview-link.card-preview-light:has(img[alt="Top Langs"])',
-    ),
+    page.locator('main a.card-preview-light:has(img[alt="Top Langs"])'),
   ).toHaveAttribute(
     "href",
     "/api/top-langs?username=anuraghazra&langs_count=4&theme=light_github",
   );
 
   // The repo card already points at the repo it describes, which is more useful.
-  const repoCardLink = page.locator('main a:has(img[alt="Readme Card"])');
-  await expect(repoCardLink).toHaveAttribute(
+  await expect(
+    page.locator('main a:has(img[alt="Readme Card"])'),
+  ).toHaveAttribute(
     "href",
     "https://github.com/anuraghazra/github-readme-stats",
   );
-
-  // A link the markdown wrote is marked too, so it shrink-wraps like the rest.
-  await expect(repoCardLink).toHaveClass("card-preview-link");
 });
 
 test("a preview that names a theme stays a single image", async ({ page }) => {

--- a/apps/frontend/e2e/docs-card-previews.spec.ts
+++ b/apps/frontend/e2e/docs-card-previews.spec.ts
@@ -45,19 +45,23 @@ test("a preview links to itself, unless the markdown links it elsewhere", async 
 
   // Opening a preview shows its query string, so each copy links to its own theme.
   await expect(
-    page.locator('main a.card-preview-light:has(img[alt="Top Langs"])'),
+    page.locator(
+      'main a.card-preview-link.card-preview-light:has(img[alt="Top Langs"])',
+    ),
   ).toHaveAttribute(
     "href",
     "/api/top-langs?username=anuraghazra&langs_count=4&theme=light_github",
   );
 
   // The repo card already points at the repo it describes, which is more useful.
-  await expect(
-    page.locator('main a:has(img[alt="Readme Card"])'),
-  ).toHaveAttribute(
+  const repoCardLink = page.locator('main a:has(img[alt="Readme Card"])');
+  await expect(repoCardLink).toHaveAttribute(
     "href",
     "https://github.com/anuraghazra/github-readme-stats",
   );
+
+  // A link the markdown wrote is marked too, so it shrink-wraps like the rest.
+  await expect(repoCardLink).toHaveClass("card-preview-link");
 });
 
 test("a preview that names a theme stays a single image", async ({ page }) => {

--- a/apps/frontend/src/plugins/rehypeCardImages.ts
+++ b/apps/frontend/src/plugins/rehypeCardImages.ts
@@ -33,10 +33,8 @@ const RELATIVE_BASE = "https://cards.invalid";
  */
 export const rehypeCardImages: RehypePlugin = () => (tree) => {
   // Typed off the tree so the plugin needs no hast types of its own.
-  type ElementNode = Extract<
-    (typeof tree.children)[number],
-    { tagName: string }
-  >;
+  type Node = (typeof tree.children)[number];
+  type ElementNode = Extract<Node, { tagName: string }>;
 
   /** Opening a preview shows how the card is configured. */
   const linked = (
@@ -52,8 +50,15 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
     children: [image],
   });
 
-  function walk(children: typeof tree.children, link: ElementNode | null) {
-    for (const [index, child] of children.entries()) {
+  /** Each image in the tree, with the siblings and the link the markdown put it in. */
+  const images: Array<{
+    image: ElementNode;
+    siblings: Array<Node>;
+    link: ElementNode | null;
+  }> = [];
+
+  function collect(children: Array<Node>, link: ElementNode | null) {
+    for (const child of children) {
       // `rehype-raw` runs after this plugin, so a card written as HTML is still text.
       if (child.type === "raw") {
         child.value = child.value.replaceAll(
@@ -67,64 +72,73 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
         continue;
       }
 
-      if (child.tagName !== "img") {
-        walk(child.children, child.tagName === "a" ? child : link);
+      if (child.tagName === "img") {
+        images.push({ image: child, siblings: children, link });
         continue;
       }
 
-      const { properties } = child;
-      const src = properties.src;
-      if (typeof src !== "string") {
-        continue;
-      }
-
-      const { pathname, search, searchParams } = new URL(src, RELATIVE_BASE);
-      const cardType = CARD_TYPE_BY_PATH[pathname];
-      if (cardType === undefined) {
-        continue;
-      }
-
-      // A hidden copy has no layout box, so only the shown theme is fetched.
-      properties.loading ??= "lazy";
-
-      // Markdown writes no class of its own; a link built below already has one.
-      if (link !== null) {
-        link.properties.className ??= [CARD_PREVIEW_LINK];
-      }
-
-      // A named theme is the point of the preview, so leave it as one image.
-      if (
-        searchParams.has("theme") ||
-        searchParams.has("theme_light") ||
-        searchParams.has("theme_dark")
-      ) {
-        if (link === null) {
-          children.splice(index, 1, linked(child));
-        }
-        continue;
-      }
-
-      const category = CATEGORY_BY_CARD_TYPE[cardType];
-
-      const themed = (variant: "light" | "dark") => {
-        const className =
-          variant === "dark" ? CARD_PREVIEW_DARK : CARD_PREVIEW_LIGHT;
-        const image = {
-          ...child,
-          properties: {
-            ...properties,
-            // Appended, not re-serialized, so the rest of the query survives verbatim.
-            src: `${src}${search === "" ? "?" : "&"}theme=${getCardThemeDefault(variant === "dark", category)}`,
-            className: [className],
-          },
-        };
-        return link === null ? linked(image, [className]) : image;
-      };
-
-      // Both copies name a theme, so the one the iterator lands on next is skipped.
-      children.splice(index, 1, themed("light"), themed("dark"));
+      collect(child.children, child.tagName === "a" ? child : link);
     }
   }
 
-  walk(tree.children, null);
+  // Collected up front, so a link built below is never mistaken for the markdown's own.
+  collect(tree.children, null);
+
+  for (const { image, siblings, link } of images) {
+    const { properties } = image;
+    const src = properties.src;
+    if (typeof src !== "string") {
+      continue;
+    }
+
+    const { pathname, search, searchParams } = new URL(src, RELATIVE_BASE);
+    const cardType = CARD_TYPE_BY_PATH[pathname];
+    if (cardType === undefined) {
+      continue;
+    }
+
+    // A hidden copy has no layout box, so only the shown theme is fetched.
+    properties.loading ??= "lazy";
+
+    /** The markdown's link, or one built around the copy; either way it is marked. */
+    const wrap = (copy: ElementNode, classes: Array<string> = []) => {
+      if (link === null) {
+        return linked(copy, classes);
+      }
+      link.properties.className = [CARD_PREVIEW_LINK];
+      return copy;
+    };
+
+    const index = siblings.indexOf(image);
+
+    // A named theme is the point of the preview, so leave it as one image.
+    if (
+      searchParams.has("theme") ||
+      searchParams.has("theme_light") ||
+      searchParams.has("theme_dark")
+    ) {
+      siblings.splice(index, 1, wrap(image));
+      continue;
+    }
+
+    const category = CATEGORY_BY_CARD_TYPE[cardType];
+
+    const themed = (variant: "light" | "dark") => {
+      const className =
+        variant === "dark" ? CARD_PREVIEW_DARK : CARD_PREVIEW_LIGHT;
+      const copy = {
+        ...image,
+        properties: {
+          ...properties,
+          // Appended, not re-serialized, so the rest of the query survives verbatim.
+          src: `${src}${search === "" ? "?" : "&"}theme=${getCardThemeDefault(variant === "dark", category)}`,
+          className: [className],
+        },
+      };
+      // The class goes on the link too, so a hidden copy leaves nothing focusable behind.
+      return wrap(copy, [className]);
+    };
+
+    siblings.splice(index, 1, themed("light"), themed("dark"));
+  }
 };

--- a/apps/frontend/src/plugins/rehypeCardImages.ts
+++ b/apps/frontend/src/plugins/rehypeCardImages.ts
@@ -15,6 +15,11 @@ const CARD_TYPE_BY_PATH: Record<string, CardType> = {
 /** An `<img>` for a card that does not already say how it loads. */
 const RAW_CARD_IMAGE = /<img(?![^>]*\bloading=)(?=[^>]*\bsrc="\/api)/g;
 
+/* `styles/starlight-theme.css` styles them; keep the class names in sync with that file. */
+const CARD_PREVIEW_LINK = "card-preview-link";
+const CARD_PREVIEW_LIGHT = "card-preview-light";
+const CARD_PREVIEW_DARK = "card-preview-dark";
+
 /** Card URLs are root-relative, so `URL` needs a base it never reads. */
 const RELATIVE_BASE = "https://cards.invalid";
 
@@ -36,15 +41,18 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
   /** Opening a preview shows how the card is configured. */
   const linked = (
     image: ElementNode,
-    className?: Array<string>,
+    classes: Array<string> = [],
   ): ElementNode => ({
     type: "element",
     tagName: "a",
-    properties: { href: image.properties.src, className },
+    properties: {
+      href: image.properties.src,
+      className: [CARD_PREVIEW_LINK, ...classes],
+    },
     children: [image],
   });
 
-  function walk(children: typeof tree.children, insideLink: boolean) {
+  function walk(children: typeof tree.children, link: ElementNode | null) {
     for (const [index, child] of children.entries()) {
       // `rehype-raw` runs after this plugin, so a card written as HTML is still text.
       if (child.type === "raw") {
@@ -60,7 +68,7 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
       }
 
       if (child.tagName !== "img") {
-        walk(child.children, insideLink || child.tagName === "a");
+        walk(child.children, child.tagName === "a" ? child : link);
         continue;
       }
 
@@ -79,13 +87,18 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
       // A hidden copy has no layout box, so only the shown theme is fetched.
       properties.loading ??= "lazy";
 
+      // Markdown writes no class of its own; a link built below already has one.
+      if (link !== null) {
+        link.properties.className ??= [CARD_PREVIEW_LINK];
+      }
+
       // A named theme is the point of the preview, so leave it as one image.
       if (
         searchParams.has("theme") ||
         searchParams.has("theme_light") ||
         searchParams.has("theme_dark")
       ) {
-        if (!insideLink) {
+        if (link === null) {
           children.splice(index, 1, linked(child));
         }
         continue;
@@ -94,11 +107,8 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
       const category = CATEGORY_BY_CARD_TYPE[cardType];
 
       const themed = (variant: "light" | "dark") => {
-        // `styles/starlight-theme.css` hides the class that does not match the
-        // site theme; keep class names in sync with that file. It also goes on
-        // the link, so a hidden copy leaves nothing focusable behind.
         const className =
-          variant === "dark" ? "card-preview-dark" : "card-preview-light";
+          variant === "dark" ? CARD_PREVIEW_DARK : CARD_PREVIEW_LIGHT;
         const image = {
           ...child,
           properties: {
@@ -108,7 +118,7 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
             className: [className],
           },
         };
-        return insideLink ? image : linked(image, [className]);
+        return link === null ? linked(image, [className]) : image;
       };
 
       // Both copies name a theme, so the one the iterator lands on next is skipped.
@@ -116,5 +126,5 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
     }
   }
 
-  walk(tree.children, false);
+  walk(tree.children, null);
 };

--- a/apps/frontend/src/plugins/rehypeCardImages.ts
+++ b/apps/frontend/src/plugins/rehypeCardImages.ts
@@ -16,7 +16,6 @@ const CARD_TYPE_BY_PATH: Record<string, CardType> = {
 const RAW_CARD_IMAGE = /<img(?![^>]*\bloading=)(?=[^>]*\bsrc="\/api)/g;
 
 /* `styles/starlight-theme.css` styles them; keep the class names in sync with that file. */
-const CARD_PREVIEW_LINK = "card-preview-link";
 const CARD_PREVIEW_LIGHT = "card-preview-light";
 const CARD_PREVIEW_DARK = "card-preview-dark";
 
@@ -39,25 +38,22 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
   /** Opening a preview shows how the card is configured. */
   const linked = (
     image: ElementNode,
-    classes: Array<string> = [],
+    className?: Array<string>,
   ): ElementNode => ({
     type: "element",
     tagName: "a",
-    properties: {
-      href: image.properties.src,
-      className: [CARD_PREVIEW_LINK, ...classes],
-    },
+    properties: { href: image.properties.src, className },
     children: [image],
   });
 
-  /** Each image in the tree, with the siblings and the link the markdown put it in. */
+  /** Each image in the tree, with its siblings and whether the markdown linked it. */
   const images: Array<{
     image: ElementNode;
     siblings: Array<Node>;
-    link: ElementNode | null;
+    insideLink: boolean;
   }> = [];
 
-  function collect(children: Array<Node>, link: ElementNode | null) {
+  function collect(children: Array<Node>, insideLink: boolean) {
     for (const child of children) {
       // `rehype-raw` runs after this plugin, so a card written as HTML is still text.
       if (child.type === "raw") {
@@ -73,18 +69,18 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
       }
 
       if (child.tagName === "img") {
-        images.push({ image: child, siblings: children, link });
+        images.push({ image: child, siblings: children, insideLink });
         continue;
       }
 
-      collect(child.children, child.tagName === "a" ? child : link);
+      collect(child.children, insideLink || child.tagName === "a");
     }
   }
 
-  // Collected up front, so a link built below is never mistaken for the markdown's own.
-  collect(tree.children, null);
+  // Collected before anything is rewritten, so a copy added below is never revisited.
+  collect(tree.children, false);
 
-  for (const { image, siblings, link } of images) {
+  for (const { image, siblings, insideLink } of images) {
     const { properties } = image;
     const src = properties.src;
     if (typeof src !== "string") {
@@ -100,15 +96,6 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
     // A hidden copy has no layout box, so only the shown theme is fetched.
     properties.loading ??= "lazy";
 
-    /** The markdown's link, or one built around the copy; either way it is marked. */
-    const wrap = (copy: ElementNode, classes: Array<string> = []) => {
-      if (link === null) {
-        return linked(copy, classes);
-      }
-      link.properties.className = [CARD_PREVIEW_LINK];
-      return copy;
-    };
-
     const index = siblings.indexOf(image);
 
     // A named theme is the point of the preview, so leave it as one image.
@@ -117,7 +104,9 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
       searchParams.has("theme_light") ||
       searchParams.has("theme_dark")
     ) {
-      siblings.splice(index, 1, wrap(image));
+      if (!insideLink) {
+        siblings.splice(index, 1, linked(image));
+      }
       continue;
     }
 
@@ -136,7 +125,7 @@ export const rehypeCardImages: RehypePlugin = () => (tree) => {
         },
       };
       // The class goes on the link too, so a hidden copy leaves nothing focusable behind.
-      return wrap(copy, [className]);
+      return insideLink ? copy : linked(copy, [className]);
     };
 
     siblings.splice(index, 1, themed("light"), themed("dark"));

--- a/apps/frontend/src/styles/starlight-theme.css
+++ b/apps/frontend/src/styles/starlight-theme.css
@@ -19,6 +19,11 @@
   --sl-color-bg-sidebar: #0d1117;
 }
 
+/* Prose styles render images as blocks; shrink-wrap any link that wraps one. */
+a:has(> img) {
+  display: inline-block;
+}
+
 /* Prose styles render images as blocks, so the row is explicit. */
 .card-row {
   display: flex;

--- a/apps/frontend/src/styles/starlight-theme.css
+++ b/apps/frontend/src/styles/starlight-theme.css
@@ -19,11 +19,6 @@
   --sl-color-bg-sidebar: #0d1117;
 }
 
-/* Prose styles render images as blocks; shrink-wrap any link that wraps one. */
-a:has(> img) {
-  display: inline-block;
-}
-
 /* Prose styles render images as blocks, so the row is explicit. */
 .card-row {
   display: flex;
@@ -40,6 +35,14 @@ a:has(> img) {
 .card-row img {
   max-width: 100%;
   height: auto;
+}
+
+/*
+ * Prose styles render images as blocks,  so a link around a card would otherwise stretch the whole column. 
+ * `plugins/rehypeCardImages.ts` writes this class; keep the class name in sync with that file.
+ */
+.card-preview-link {
+  display: inline-block;
 }
 
 /*

--- a/apps/frontend/src/styles/starlight-theme.css
+++ b/apps/frontend/src/styles/starlight-theme.css
@@ -19,6 +19,11 @@
   --sl-color-bg-sidebar: #0d1117;
 }
 
+/* Prose styles render images as blocks; shrink-wrap any link that wraps one. */
+a:has(> img) {
+  display: inline-block;
+}
+
 /* Prose styles render images as blocks, so the row is explicit. */
 .card-row {
   display: flex;
@@ -35,14 +40,6 @@
 .card-row img {
   max-width: 100%;
   height: auto;
-}
-
-/*
- * Prose styles render images as blocks,  so a link around a card would otherwise stretch the whole column. 
- * `plugins/rehypeCardImages.ts` writes this class; keep the class name in sync with that file.
- */
-.card-preview-link {
-  display: inline-block;
 }
 
 /*


### PR DESCRIPTION
- Built on top of #531 

---

- `starlight-theme.css` shrink-wraps `.card-preview-link` instead of every `a:has(> img)`, 
  so links around non-card images (the Vercel deploy button on the Deploy page) keep their prose layout.
- The walk is now two flat passes: collect every image, then rewrite each once. 
  Nothing is spliced mid-iteration, so a copy the plugin adds is never revisited.