### PR TITLE
i18n(zh-tw): Edit Traditional Chinese translations for stats

### DIFF
--- a/packages/core/src/translations.ts
+++ b/packages/core/src/translations.ts
@@ -511,21 +511,27 @@ const statCardLocales = ({
     },
     "statcard.prs-authored": {
       en: "PRs Created",
+      "zh-tw": "建立的拉取請求",
     },
     "statcard.prs-commented": {
       en: "PRs Commented",
+      "zh-tw": "參與討論的拉取請求",
     },
     "statcard.prs-reviewed": {
       en: "PRs Reviewed",
+      "zh-tw": "審核的拉取請求",
     },
     "statcard.issues-authored": {
       en: "Issues Created",
+      "zh-tw": "建立的議題",
     },
     "statcard.issues-commented": {
       en: "Issues Commented",
+      "zh-tw": "參與討論的議題",
     },
     "statcard.contributions": {
       en: "Total Contributions",
+      "zh-tw": "總貢獻數量",
     },
     "statcard.prs-merged": {
       en: "Total PRs Merged",
@@ -727,18 +733,23 @@ const repoCardLocales = {
   },
   "repocard.prs-authored": {
     en: "my created PRs",
+    "zh-tw": "我所創建的拉取請求",
   },
   "repocard.prs-commented": {
     en: "my commented PRs",
+    "zh-tw": "我所參與的拉取請求",
   },
   "repocard.prs-reviewed": {
     en: "my reviewed PRs",
+    "zh-tw": "我所審核的拉取請求",
   },
   "repocard.issues-authored": {
     en: "my created issues",
+    "zh-tw": "我所創建的議題",
   },
   "repocard.issues-commented": {
     en: "my commented issues",
+    "zh-tw": "我所參與的議題",
   },
 };
 


### PR DESCRIPTION
> TL;DR: I have added the translation keys for Traditional Chinese to ensure that the statistics card does not show error messages due to lack of translation keys.

Now, when I set the locale to "zh-tw", the thumbnail does not show anything, but directly tells me that the i18n key for the corresponding language is missing.
Therefore, I created this pull request to complete the translation key for Traditional Chinese to ensure that users can see the statistics card normally.

<img width="591" height="137" alt="image" src="https://github.com/user-attachments/assets/d2a6e599-2a26-4b3f-b9d9-a79ffbb8e2e0" />

At the same time, I also suggest that you consider setting the i18n Fallback project, so that when the translation key is lacking, the system will try to display the content in English (or display the missing translation key, or use any other language).
