### PR TITLE
handle transient errors when fetching contributed-to data

### DIFF
--- a/packages/core/src/fetchers/stats.ts
+++ b/packages/core/src/fetchers/stats.ts
@@ -412,6 +412,8 @@ const fetchAllTimeReposContributedTo = async (
   const pending = years.map(getGitHubYearRange);
   // halved when GitHub rejects a request for exceeding its resource limits, increases on success
   let rangesPerRequest = MAX_RANGES_PER_REQUEST;
+  let emptyResponseRetries = 0;
+  const MAX_EMPTY_RESPONSE_RETRIES = 3;
 
   while (pending.length > 0) {
     const chunk = pending.slice(0, rangesPerRequest);
@@ -424,11 +426,24 @@ const fetchAllTimeReposContributedTo = async (
       { login: canonicalUsername, maxRepositories: MAX_REPOSITORIES_LIMIT },
       pat,
     );
+    if (res.status === 502 || res.status === 504) {
+      if (chunk.length > 1) {
+        rangesPerRequest = Math.floor(chunk.length / 2);
+        logger.log(
+          `Gateway timeout (${res.status}), retrying with ${rangesPerRequest} range(s) per request...`,
+        );
+        continue;
+      }
+      throw new CustomError(
+        REPOS_CONTRIBUTED_TO_ERROR,
+        CustomError.GRAPHQL_ERROR,
+      );
+    }
     if (res.data.errors) {
       if (isResourceLimitsExceeded(res.data.errors) && chunk.length > 1) {
         rangesPerRequest = Math.floor(chunk.length / 2);
         logger.log(
-          `Resource limits exceeded, retrying with ${rangesPerRequest} ranges per request...`,
+          `Resource limits exceeded, retrying with ${rangesPerRequest} range(s) per request...`,
         );
         continue;
       }
@@ -438,6 +453,20 @@ const fetchAllTimeReposContributedTo = async (
         REPOS_CONTRIBUTED_TO_ERROR,
       );
     }
+    if (typeof res.data !== "object") {
+      if (emptyResponseRetries < MAX_EMPTY_RESPONSE_RETRIES) {
+        emptyResponseRetries++;
+        logger.log(
+          `Empty response from GitHub, retrying (${emptyResponseRetries}/${MAX_EMPTY_RESPONSE_RETRIES})...`,
+        );
+        continue;
+      }
+      throw new CustomError(
+        REPOS_CONTRIBUTED_TO_ERROR,
+        CustomError.GRAPHQL_ERROR,
+      );
+    }
+    emptyResponseRetries = 0;
     const user = res.data.data.user;
     if (!user) {
       throw new CustomError(

--- a/packages/core/src/fetchers/stats.ts
+++ b/packages/core/src/fetchers/stats.ts
@@ -4,18 +4,13 @@ import githubUsernameRegex from "github-username-regex";
 
 import { calculateRank } from "../calculateRank.js";
 import { getConfig } from "../common/config.js";
-import type { GitHubDateRange } from "../common/date.js";
 import { getGitHubYearRange, toGitHubDateTime } from "../common/date.js";
 import { CustomError, MissingParamError } from "../common/error.js";
 import { wrapTextMultiline } from "../common/fmt.js";
 import { createGraphQLFetcher } from "../common/http.js";
 import type { GraphQLResponse } from "../common/http.js";
 import { logger } from "../common/log.js";
-import {
-  buildSearchFilter,
-  chunkArray,
-  parseOwnerAffiliations,
-} from "../common/ops.js";
+import { buildSearchFilter, parseOwnerAffiliations } from "../common/ops.js";
 import { retryer } from "../common/retryer.js";
 import { buildContributionsDocument } from "../graphql/contributionsDocument.js";
 import {
@@ -363,21 +358,40 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /**
  * Ranges per request.
  * Each costs roughly `4 * MAX_REPOSITORIES_LIMIT` nodes,
- * so an unchunked round of a heavily split account would breach GitHub's 500k node ceiling
- * and lose the ranges that had already resolved along with it.
+ * so an unchunked request for a heavily split account would breach GitHub's 500k node ceiling.
+ * GitHub can still reject a request of this size, in which case the chunk size is halved
+ * and the request retried; it is doubled back up to this maximum after every success.
  */
-const MAX_RANGES_PER_REQUEST = 100;
+const MAX_RANGES_PER_REQUEST = 400;
 
 const REPOS_CONTRIBUTED_TO_ERROR =
   "Something went wrong while trying to retrieve the repository contributions data using the GraphQL API.";
+
+/** GraphQL error type GitHub returns when a query exceeds its node/complexity budget. */
+const RESOURCE_LIMITS_EXCEEDED = "RESOURCE_LIMITS_EXCEEDED";
+
+/**
+ * Whether GitHub rejected the query for returning too many results.
+ *
+ * @see https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#other-resource-limits
+ *
+ * @param errors Errors from the response envelope.
+ * @returns True if the query has to be retried with fewer ranges.
+ */
+const isResourceLimitsExceeded = (
+  errors: NonNullable<GraphQLResponse<unknown>["data"]["errors"]>,
+): boolean => errors.some((error) => error.type === RESOURCE_LIMITS_EXCEEDED);
 
 /**
  * Count the repositories a user contributed to across every contribution year.
  *
  * `repositoriesContributedTo` spans at most one year,
  * so every year is fetched as an aliased `contributionsCollection(from, to)` in one request and the repos de-duplicated.
+ * Ranges are worked off a queue, `MAX_RANGES_PER_REQUEST` at a time.
  * A range returning `MAX_REPOSITORIES_LIMIT` results may have more,
- * so it is halved and requeried in the next round.
+ * so it is halved and both halves are queued again.
+ * When GitHub rejects a request with `RESOURCE_LIMITS_EXCEEDED`,
+ * the number of ranges per request is halved and the request retried.
  *
  * Whether private contributions are included depends on the used PAT.
  *
@@ -395,97 +409,101 @@ const fetchAllTimeReposContributedTo = async (
   pat: string | null,
 ): Promise<number> => {
   const repos = new Set<string>();
-  let pending = years.map(getGitHubYearRange);
+  const pending = years.map(getGitHubYearRange);
+  // halved when GitHub rejects a request for exceeding its resource limits, increases on success
+  let rangesPerRequest = MAX_RANGES_PER_REQUEST;
 
   while (pending.length > 0) {
-    const nextPending: Array<GitHubDateRange> = [];
-
-    for (const chunk of chunkArray(pending, MAX_RANGES_PER_REQUEST)) {
-      const fetcher = createGraphQLFetcher(
-        buildReposContributedToDocument(chunk, includeOwnRepos),
-        "bearer",
-      );
-      const res = await retryer(
-        fetcher,
-        { login: canonicalUsername, maxRepositories: MAX_REPOSITORIES_LIMIT },
-        pat,
-      );
-      if (res.data.errors) {
-        throw graphqlError(
-          res.data.errors,
-          res.statusText,
-          REPOS_CONTRIBUTED_TO_ERROR,
+    const chunk = pending.slice(0, rangesPerRequest);
+    const fetcher = createGraphQLFetcher(
+      buildReposContributedToDocument(chunk, includeOwnRepos),
+      "bearer",
+    );
+    const res = await retryer(
+      fetcher,
+      { login: canonicalUsername, maxRepositories: MAX_REPOSITORIES_LIMIT },
+      pat,
+    );
+    if (res.data.errors) {
+      if (isResourceLimitsExceeded(res.data.errors) && chunk.length > 1) {
+        rangesPerRequest = Math.floor(chunk.length / 2);
+        logger.log(
+          `Resource limits exceeded, retrying with ${rangesPerRequest} ranges per request...`,
         );
+        continue;
       }
-      const user = res.data.data.user;
-      if (!user) {
+      throw graphqlError(
+        res.data.errors,
+        res.statusText,
+        REPOS_CONTRIBUTED_TO_ERROR,
+      );
+    }
+    const user = res.data.data.user;
+    if (!user) {
+      throw new CustomError(
+        REPOS_CONTRIBUTED_TO_ERROR,
+        CustomError.GRAPHQL_ERROR,
+      );
+    }
+
+    pending.splice(0, chunk.length);
+    rangesPerRequest = Math.min(
+      MAX_RANGES_PER_REQUEST,
+      Math.ceil(rangesPerRequest * 1.25),
+    );
+
+    for (const [index, range] of chunk.entries()) {
+      const rangeResponse = user[`range_${index}`];
+      if (!rangeResponse) {
         throw new CustomError(
           REPOS_CONTRIBUTED_TO_ERROR,
           CustomError.GRAPHQL_ERROR,
         );
       }
 
-      for (const [index, range] of chunk.entries()) {
-        const rangeResponse = user[`range_${index}`];
-        if (!rangeResponse) {
-          throw new CustomError(
-            REPOS_CONTRIBUTED_TO_ERROR,
-            CustomError.GRAPHQL_ERROR,
-          );
-        }
+      const lists = [
+        rangeResponse.commitContributionsByRepository,
+        rangeResponse.issueContributionsByRepository,
+        rangeResponse.pullRequestContributionsByRepository,
+        (rangeResponse.repositoryContributions?.nodes ?? []).filter(
+          (node) => node !== null,
+        ),
+      ];
+      const isSaturated = lists.some(
+        (list) => list.length >= MAX_REPOSITORIES_LIMIT,
+      );
 
-        const lists = [
-          rangeResponse.commitContributionsByRepository,
-          rangeResponse.issueContributionsByRepository,
-          rangeResponse.pullRequestContributionsByRepository,
-          (rangeResponse.repositoryContributions?.nodes ?? []).filter(
-            (node) => node !== null,
-          ),
-        ];
-        const isSaturated = lists.some(
-          (list) => list.length >= MAX_REPOSITORIES_LIMIT,
+      const rangeDays = Math.round(
+        (range.to.getTime() - range.from.getTime()) / MS_PER_DAY,
+      );
+      if (isSaturated && rangeDays >= 2) {
+        const mid = new Date(
+          range.from.getTime() + Math.floor(rangeDays / 2) * MS_PER_DAY,
         );
-
-        const rangeDays = Math.round(
-          (range.to.getTime() - range.from.getTime()) / MS_PER_DAY,
+        logger.log(
+          `Range ${range.from.toISOString()} - ${range.to.toISOString()} is saturated, splitting and retrying...`,
         );
-        // a range of 1 day or less can't be split any further
-        if (isSaturated && rangeDays >= 2) {
-          // every `from` sits on UTC midnight, so the split lands on a day boundary too
-          const mid = new Date(
-            range.from.getTime() + Math.floor(rangeDays / 2) * MS_PER_DAY,
-          );
-          // GitHub only reads the date portion,
-          // so the first half ends 1 second before `mid` to keep the halves from sharing a day
-          nextPending.push(
-            { from: range.from, to: new Date(mid.getTime() - 1000) },
-            { from: mid, to: range.to },
-          );
-          continue;
-        }
-        if (isSaturated) {
-          logger.log(
-            `Range ${range.from.toISOString()} - ${range.to.toISOString()} is saturated but cannot be split further.`,
-          );
-        }
+        // GitHub only reads the date portion,
+        // so the first half ends 1 second before `mid` to keep the halves from sharing a day
+        pending.push(
+          { from: range.from, to: new Date(mid.getTime() - 1000) },
+          { from: mid, to: range.to },
+        );
+        continue;
+      }
+      if (isSaturated) {
+        logger.log(
+          `Range ${range.from.toISOString()} - ${range.to.toISOString()} is saturated but cannot be split further.`,
+        );
+      }
 
-        for (const { repository } of lists.flat()) {
-          const name = repository.nameWithOwner;
-          if (includeOwnRepos || !name.startsWith(`${canonicalUsername}/`)) {
-            repos.add(name);
-          }
+      for (const { repository } of lists.flat()) {
+        const name = repository.nameWithOwner;
+        if (includeOwnRepos || !name.startsWith(`${canonicalUsername}/`)) {
+          repos.add(name);
         }
       }
     }
-
-    // each saturated range pushes both of its halves
-    const saturatedCount = nextPending.length / 2;
-    if (saturatedCount > 0) {
-      logger.log(
-        `found ${saturatedCount} saturated ranges, splitting and retrying...`,
-      );
-    }
-    pending = nextPending;
   }
 
   return repos.size;

--- a/packages/core/src/fetchers/stats.ts
+++ b/packages/core/src/fetchers/stats.ts
@@ -360,7 +360,7 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
  * Each costs roughly `4 * MAX_REPOSITORIES_LIMIT` nodes,
  * so an unchunked request for a heavily split account would breach GitHub's 500k node ceiling.
  * GitHub can still reject a request of this size, in which case the chunk size is halved
- * and the request retried; it is doubled back up to this maximum after every success.
+ * and the request retried; it is increased back up to this maximum after every success.
  */
 const MAX_RANGES_PER_REQUEST = 400;
 
@@ -387,11 +387,12 @@ const isResourceLimitsExceeded = (
  *
  * `repositoriesContributedTo` spans at most one year,
  * so every year is fetched as an aliased `contributionsCollection(from, to)` in one request and the repos de-duplicated.
- * Ranges are worked off a queue, `MAX_RANGES_PER_REQUEST` at a time.
+ * Ranges are worked off a queue, multiple ranges at a time.
  * A range returning `MAX_REPOSITORIES_LIMIT` results may have more,
  * so it is halved and both halves are queued again.
- * When GitHub rejects a request with `RESOURCE_LIMITS_EXCEEDED`,
- * the number of ranges per request is halved and the request retried.
+ * When GitHub rejects a request with `RESOURCE_LIMITS_EXCEEDED` or a timeout,
+ * it is retried with half as many ranges.
+ * When GitHub rejects a request with an empty response, it is retried up to 3 times.
  *
  * Whether private contributions are included depends on the used PAT.
  *

--- a/packages/core/tests/fetchStats.test.ts
+++ b/packages/core/tests/fetchStats.test.ts
@@ -206,7 +206,7 @@ const data_stats_many_years: GraphQLBody<UserInfoQuery> = {
   },
 };
 
-/** GitHub's answer when a query asks for more than it is willing to resolve. */
+/** GitHub's response when a query asks for more than it is willing to resolve. */
 const data_resource_limits_exceeded: GraphQLBody<ReposContributedToQuery> = {
   data: { user: null },
   errors: [
@@ -216,6 +216,10 @@ const data_resource_limits_exceeded: GraphQLBody<ReposContributedToQuery> = {
     },
   ],
 };
+
+/** GitHub's response when a query takes too long. */
+const message_timeout =
+  "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n";
 
 const error: GraphQLBody<UserInfoQuery> = {
   data: { user: null },
@@ -676,10 +680,14 @@ describe("Test fetchStats", () => {
    * Mock the contributed-to query to reject requests with more than `maxRanges` ranges,
    * like GitHub does when a query is too big.
    *
-   * @param maxRanges maximum number of accepted ranges.
+   * @param maxRanges Maximum number of accepted ranges.
+   * @param rejection Axios response tuple `[status, body]` returned when the limit is exceeded.
    * @returns Range counts of all contributed-to requests, in order; filled as they arrive.
    */
-  const mockRangeLimit = (maxRanges: number): Array<number> => {
+  const mockRangeLimit = (
+    maxRanges: number,
+    rejection: [number, unknown],
+  ): Array<number> => {
     const allRangeCounts: Array<number> = [];
 
     mock.reset();
@@ -691,7 +699,7 @@ describe("Test fetchStats", () => {
       const rangeCount = (req.query.match(/range_\d+:/g) ?? []).length;
       allRangeCounts.push(rangeCount);
       if (rangeCount > maxRanges) {
-        return [200, data_resource_limits_exceeded];
+        return rejection;
       }
 
       const ranges: QueryUser<ReposContributedToQuery> = {};
@@ -705,7 +713,7 @@ describe("Test fetchStats", () => {
   };
 
   it("should halve ranges when resource limits exceeded, should raise again on success", async () => {
-    const rangeCounts = mockRangeLimit(2);
+    const rangeCounts = mockRangeLimit(2, [200, data_resource_limits_exceeded]);
 
     const stats = await fetchStatsWith({ include_all_time_contribs: true });
 
@@ -714,12 +722,83 @@ describe("Test fetchStats", () => {
   });
 
   it("should throw when a single range already exceeds the resource limits", async () => {
-    const rangeCounts = mockRangeLimit(0);
+    const rangeCounts = mockRangeLimit(0, [200, data_resource_limits_exceeded]);
 
     await expect(
       fetchStatsWith({ include_all_time_contribs: true }),
     ).rejects.toThrow("Resource limits for this query exceeded.");
 
     expect(rangeCounts.at(-1)).toBe(1);
+  });
+
+  it.each([502, 504])(
+    "should halve ranges on %i gateway timeout and raise again on success",
+    async (status) => {
+      const rangeCounts = mockRangeLimit(2, [status, message_timeout]);
+
+      const stats = await fetchStatsWith({ include_all_time_contribs: true });
+
+      expect(stats.allTimeContributedTo).toBe(2);
+      expect(rangeCounts).toEqual([9, 4, 2, 3, 1, 2, 3, 1, 2, 1]);
+    },
+  );
+
+  it.each([502, 504])(
+    "should throw when a single range already returns %i",
+    async (status) => {
+      const rangeCounts = mockRangeLimit(0, [status, message_timeout]);
+
+      await expect(
+        fetchStatsWith({ include_all_time_contribs: true }),
+      ).rejects.toThrow(
+        "Something went wrong while trying to retrieve the repository contributions data using the GraphQL API.",
+      );
+
+      expect(rangeCounts.at(-1)).toBe(1);
+    },
+  );
+
+  it("should retry on empty contributed-to response and succeed within retry limit", async () => {
+    let contributedToCallCount = 0;
+
+    mock.reset();
+    mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+      const req = JSON.parse(cfg.data as string) as { query: string };
+      if (!req.query.includes("userReposContributedTo")) {
+        return [200, data_stats];
+      }
+      contributedToCallCount++;
+      // return empty body for first 3 attempts, then a valid response
+      return contributedToCallCount <= 3
+        ? [200, ""]
+        : [200, data_repos_contributed_to];
+    });
+
+    const stats = await fetchStatsWith({ include_all_time_contribs: true });
+
+    expect(stats.allTimeContributedTo).toBe(3);
+    expect(contributedToCallCount).toBe(4);
+  });
+
+  it("should throw when empty contributed-to responses exhaust retry limit", async () => {
+    let contributedToCallCount = 0;
+
+    mock.reset();
+    mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+      const req = JSON.parse(cfg.data as string) as { query: string };
+      if (!req.query.includes("userReposContributedTo")) {
+        return [200, data_stats];
+      }
+      contributedToCallCount++;
+      return [200, ""];
+    });
+
+    await expect(
+      fetchStatsWith({ include_all_time_contribs: true }),
+    ).rejects.toThrow(
+      "Something went wrong while trying to retrieve the repository contributions data using the GraphQL API.",
+    );
+
+    expect(contributedToCallCount).toBe(4);
   });
 });

--- a/packages/core/tests/fetchStats.test.ts
+++ b/packages/core/tests/fetchStats.test.ts
@@ -155,26 +155,26 @@ const data_contributions: GraphQLBody<ContributionsQuery> = {
   },
 };
 
+const contributed_to_range_0 = {
+  commitContributionsByRepository: [
+    { repository: { nameWithOwner: "org/repo1" } },
+  ],
+  issueContributionsByRepository: [
+    { repository: { nameWithOwner: "org/repo2" } },
+  ],
+  pullRequestContributionsByRepository: [],
+  repositoryContributions: {
+    nodes: [{ repository: { nameWithOwner: "anuraghazra/created-repo" } }],
+  },
+};
+
 // `repositoryContributions` only ever returns repos the user owns,
 // so every entry under it is `anuraghazra/*`.
 // It repeats across ranges to exercise de-duplication.
 const data_repos_contributed_to: GraphQLBody<ReposContributedToQuery> = {
   data: {
     user: {
-      range_0: {
-        commitContributionsByRepository: [
-          { repository: { nameWithOwner: "org/repo1" } },
-        ],
-        issueContributionsByRepository: [
-          { repository: { nameWithOwner: "org/repo2" } },
-        ],
-        pullRequestContributionsByRepository: [],
-        repositoryContributions: {
-          nodes: [
-            { repository: { nameWithOwner: "anuraghazra/created-repo" } },
-          ],
-        },
-      },
+      range_0: contributed_to_range_0,
       range_1: {
         commitContributionsByRepository: [
           { repository: { nameWithOwner: "anuraghazra/own-repo" } },
@@ -191,6 +191,30 @@ const data_repos_contributed_to: GraphQLBody<ReposContributedToQuery> = {
       },
     },
   },
+};
+
+const data_stats_many_years: GraphQLBody<UserInfoQuery> = {
+  data: {
+    user: {
+      ...user_stats,
+      contributionsCollection: {
+        contributionYears: [
+          2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025, 2026,
+        ],
+      },
+    },
+  },
+};
+
+/** GitHub's answer when a query asks for more than it is willing to resolve. */
+const data_resource_limits_exceeded: GraphQLBody<ReposContributedToQuery> = {
+  data: { user: null },
+  errors: [
+    {
+      type: "RESOURCE_LIMITS_EXCEEDED",
+      message: "Resource limits for this query exceeded.",
+    },
+  ],
 };
 
 const error: GraphQLBody<UserInfoQuery> = {
@@ -645,7 +669,57 @@ describe("Test fetchStats", () => {
     const stats = await fetchStatsWith({ include_all_time_contribs: true });
 
     expect(stats.allTimeContributedTo).toBe(100);
-    // rounds past MAX_RANGES_PER_REQUEST ranges take more than one request each
-    expect(requestCount).toEqual(23);
+    expect(requestCount).toEqual(12);
+  });
+
+  /**
+   * Mock the contributed-to query to reject requests with more than `maxRanges` ranges,
+   * like GitHub does when a query is too big.
+   *
+   * @param maxRanges maximum number of accepted ranges.
+   * @returns Range counts of all contributed-to requests, in order; filled as they arrive.
+   */
+  const mockRangeLimit = (maxRanges: number): Array<number> => {
+    const allRangeCounts: Array<number> = [];
+
+    mock.reset();
+    mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+      const req = JSON.parse(cfg.data as string) as { query: string };
+      if (!req.query.includes("userReposContributedTo")) {
+        return [200, data_stats_many_years];
+      }
+      const rangeCount = (req.query.match(/range_\d+:/g) ?? []).length;
+      allRangeCounts.push(rangeCount);
+      if (rangeCount > maxRanges) {
+        return [200, data_resource_limits_exceeded];
+      }
+
+      const ranges: QueryUser<ReposContributedToQuery> = {};
+      for (let i = 0; i < rangeCount; i++) {
+        ranges[`range_${i}`] = contributed_to_range_0;
+      }
+      return [200, { data: { user: ranges } }];
+    });
+
+    return allRangeCounts;
+  };
+
+  it("should halve ranges when resource limits exceeded, should raise again on success", async () => {
+    const rangeCounts = mockRangeLimit(2);
+
+    const stats = await fetchStatsWith({ include_all_time_contribs: true });
+
+    expect(stats.allTimeContributedTo).toBe(2);
+    expect(rangeCounts).toEqual([9, 4, 2, 3, 1, 2, 3, 1, 2, 1]);
+  });
+
+  it("should throw when a single range already exceeds the resource limits", async () => {
+    const rangeCounts = mockRangeLimit(0);
+
+    await expect(
+      fetchStatsWith({ include_all_time_contribs: true }),
+    ).rejects.toThrow("Resource limits for this query exceeded.");
+
+    expect(rangeCounts.at(-1)).toBe(1);
   });
 });


### PR DESCRIPTION
Handle timeouts, "RESOURCE_LIMITS_EXCEEDED" type responses and empty responses. For the first two we retry with less data; for the last we retry 3 times.